### PR TITLE
Elliptic curve point serialization and FROST group commitment encoding

### DIFF
--- a/frost/bip340.go
+++ b/frost/bip340.go
@@ -102,7 +102,7 @@ func (b *Bip340Ciphersuite) H3(m []byte, ms ...[]byte) *big.Int {
 }
 
 // H4 is the implementation of H4(m) function from [FROST].
-func (b *Bip340Ciphersuite) H4(m []byte, ms ...[]byte) []byte {
+func (b *Bip340Ciphersuite) H4(m []byte) []byte {
 	// From [FROST], we know the tag should be DST = contextString || "msg".
 	dst := concat(b.contextString(), []byte("msg"))
 	hash := b.hash(dst, m)
@@ -110,7 +110,7 @@ func (b *Bip340Ciphersuite) H4(m []byte, ms ...[]byte) []byte {
 }
 
 // H5 is the implementation of H5(m) function from [FROST].
-func (b *Bip340Ciphersuite) H5(m []byte, ms ...[]byte) []byte {
+func (b *Bip340Ciphersuite) H5(m []byte) []byte {
 	// From [FROST], we know the tag should be DST = contextString || "com".
 	dst := concat(b.contextString(), []byte("com"))
 	hash := b.hash(dst, m)

--- a/frost/bip340.go
+++ b/frost/bip340.go
@@ -64,6 +64,9 @@ func (b *Bip340Curve) SerializePoint(p *Point) []byte {
 // byte slice length must be equal to SerializedPointLength(). Otherwise,
 // the function returns nil.
 func (b *Bip340Curve) DeserializePoint(bytes []byte) *Point {
+
+	// TODO: validate if point is on the curve
+
 	x, y := b.Unmarshal(bytes)
 	if x == nil || y == nil {
 		return nil

--- a/frost/bip340.go
+++ b/frost/bip340.go
@@ -38,6 +38,12 @@ func (bc *Bip340Curve) EcBaseMul(k *big.Int) *Point {
 	return &Point{gs_x, gs_y}
 }
 
+// IsNotIdentity validates if the point lies on the curve and is not an identity
+// element.
+func (bc *Bip340Curve) IsNotIdentity(p *Point) bool {
+	return bc.IsOnCurve(p.X, p.Y)
+}
+
 // SerializedPointLength returns the byte length of a serialized curve point.
 func (b *Bip340Curve) SerializedPointLength() int {
 	// From the Marshal() function of secp256k1 go-ethereum implementation:

--- a/frost/bip340.go
+++ b/frost/bip340.go
@@ -38,6 +38,34 @@ func (bc *Bip340Curve) EcBaseMul(k *big.Int) *Point {
 	return &Point{gs_x, gs_y}
 }
 
+// SerializedPointLength returns the byte length of a serialized curve point.
+func (b *Bip340Curve) SerializedPointLength() int {
+	// From the Marshal() function of secp256k1 go-ethereum implementation:
+	// 	 byteLen := (BitCurve.BitSize + 7) >> 3
+	//   ret := make([]byte, 1+2*byteLen)
+	return 65
+}
+
+// SerializePoint serializes the provided elliptic curve point to bytes.
+// The slice length is equal to SerializedPointLength().
+func (b *Bip340Curve) SerializePoint(p *Point) []byte {
+	// Note that secp256k1 implementation uses a fixed length of
+	// (BitCurve.BitSize + 7) >> 3
+	return b.Marshal(p.X, p.Y)
+}
+
+// DeserializePoint deserializes byte slice to an elliptic curve point. The
+// byte slice length must be equal to SerializedPointLength(). Otherwise,
+// the function returns nil.
+func (b *Bip340Curve) DeserializePoint(bytes []byte) *Point {
+	x, y := b.Unmarshal(bytes)
+	if x == nil || y == nil {
+		return nil
+	}
+
+	return &Point{x, y}
+}
+
 // H1 is the implementation of H1(m) function from [FROST].
 func (b *Bip340Ciphersuite) H1(m []byte) *big.Int {
 	// From [FROST], we know the tag should be DST = contextString || "rho".

--- a/frost/bip340_test.go
+++ b/frost/bip340_test.go
@@ -8,7 +8,7 @@ import (
 	"threshold.network/roast/internal/testutils"
 )
 
-func Test_Bip340Ciphersuite_H1(t *testing.T) {
+func TestBip340CiphersuiteH1(t *testing.T) {
 	// There are no official test vectors available. Yet, we want to ensure the
 	// function does not panic for empty or nil. We also want to make sure the
 	// happy path works producing a non-zero value.
@@ -35,7 +35,7 @@ func Test_Bip340Ciphersuite_H1(t *testing.T) {
 	}
 }
 
-func Test_Bip340Ciphersuite_H2(t *testing.T) {
+func TestBip340CiphersuiteH2(t *testing.T) {
 	// There are no official test vectors available. Yet, we want to ensure the
 	// function does not panic for empty or nil. We also want to make sure the
 	// happy path works producing a non-zero value.
@@ -75,7 +75,7 @@ func Test_Bip340Ciphersuite_H2(t *testing.T) {
 	}
 }
 
-func Test_Bip340Ciphersuite_H3(t *testing.T) {
+func TestBip340CiphersuiteH3(t *testing.T) {
 	// There are no official test vectors available. Yet, we want to ensure the
 	// function does not panic for empty or nil. We also want to make sure the
 	// happy path works producing a non-zero value.
@@ -114,7 +114,7 @@ func Test_Bip340Ciphersuite_H3(t *testing.T) {
 	}
 }
 
-func Test_Bip340Ciphersuite_H4(t *testing.T) {
+func TestBip340CiphersuiteH4(t *testing.T) {
 	// There are no official test vectors available. Yet, we want to ensure the
 	// function does not panic for empty or nil. We also want to make sure the
 	// happy path works producing a non-zero value.
@@ -144,7 +144,7 @@ func Test_Bip340Ciphersuite_H4(t *testing.T) {
 	}
 }
 
-func Test_Bip340Ciphersuite_H5(t *testing.T) {
+func TestBip340CiphersuiteH5(t *testing.T) {
 	// There are no official test vectors available. Yet, we want to ensure the
 	// function does not panic for empty or nil. We also want to make sure the
 	// happy path works producing a non-zero value.
@@ -174,7 +174,7 @@ func Test_Bip340Ciphersuite_H5(t *testing.T) {
 	}
 }
 
-func Test_Bip340Ciphersuite_hashToScalar(t *testing.T) {
+func TestBip340CiphersuiteHashToScalar(t *testing.T) {
 	var tests = map[string]struct {
 		tag []byte
 		msg []byte
@@ -223,7 +223,7 @@ func Test_Bip340Ciphersuite_hashToScalar(t *testing.T) {
 	}
 }
 
-func Test_Bip340Ciphersuite_hash(t *testing.T) {
+func TestBip340CiphersuiteHash(t *testing.T) {
 	var tests = map[string]struct {
 		tag []byte
 		msg []byte

--- a/frost/ciphersuite.go
+++ b/frost/ciphersuite.go
@@ -33,6 +33,10 @@ type Curve interface {
 	// EcBaseMul returns k*G, where G is the base point of the group.
 	EcBaseMul(*big.Int) *Point
 
+	// IsNotIdentity validates if the point lies on the curve and is not an
+	// identity element.
+	IsNotIdentity(*Point) bool
+
 	// SerializedPointLength returns the byte length of a serialized curve point.
 	// The value is specific to the implementation. It is expected that the
 	// SerializePoint function always return a slice of this length and the

--- a/frost/ciphersuite.go
+++ b/frost/ciphersuite.go
@@ -1,6 +1,9 @@
 package frost
 
-import "math/big"
+import (
+	"fmt"
+	"math/big"
+)
 
 // Ciphersuite interface abstracts out the particular ciphersuite implementation
 // used for the [FROST] protocol execution. This is a strategy design pattern
@@ -58,4 +61,10 @@ type Curve interface {
 type Point struct {
 	X *big.Int // the X coordinate of the point
 	Y *big.Int // the Y coordinate of the point
+}
+
+// String transforms Point structure into a string so that it can be used
+// in logging.
+func (p *Point) String() string {
+	return fmt.Sprintf("Point[X=0x%v, Y=0x%v]", p.X.Text(16), p.Y.Text(16))
 }

--- a/frost/ciphersuite.go
+++ b/frost/ciphersuite.go
@@ -30,7 +30,24 @@ type Hashing interface {
 // Curve interface abstracts out the particular elliptic curve implementation
 // specific to the ciphersuite used.
 type Curve interface {
+	// EcBaseMul returns k*G, where G is the base point of the group.
 	EcBaseMul(*big.Int) *Point
+
+	// SerializedPointLength returns the byte length of a serialized curve point.
+	// The value is specific to the implementation. It is expected that the
+	// SerializePoint function always return a slice of this length and the
+	// DeserializePoint can only deserialize byte slice of this length.
+	SerializedPointLength() int
+
+	// SerializePoint serializes the provided elliptic curve point to bytes.
+	// The byte slice returned must always have a length equal to
+	// SerializedPointLength().
+	SerializePoint(*Point) []byte
+
+	// DeserializePoint deserializes byte slice to an elliptic curve point. The
+	// byte slice length must be equal to SerializedPointLength(). Otherwise,
+	// the function returns nil.
+	DeserializePoint([]byte) *Point
 }
 
 // Point represents a valid point on the Curve.

--- a/frost/signer_test.go
+++ b/frost/signer_test.go
@@ -1,0 +1,95 @@
+package frost
+
+import (
+	"crypto/rand"
+	"math/big"
+	"testing"
+
+	"threshold.network/roast/internal/testutils"
+)
+
+var ciphersuite = NewBip340Ciphersuite()
+var groupSize = 100
+
+func TestValidateGroupCommitment(t *testing.T) {
+	signers := createSigners(t)
+	_, commitments := executeRound1(t, signers)
+
+	signer := signers[0]
+
+	validationErrors := signer.validateGroupCommitment(commitments)
+	testutils.AssertIntsEqual(t, "number of validation errors", 0, len(validationErrors))
+}
+
+func TestValidateGroupCommitments_Errors(t *testing.T) {
+	signers := createSigners(t)
+	_, commitments := executeRound1(t, signers)
+
+	tmp := commitments[31]
+	// at the position where we'd expect a commitment from signer 32 we have
+	// a commitment from signer 51
+	commitments[31] = commitments[50]
+	// at the position where we'd expect a commitment from signer 51 we have
+	// a commitment from signer 32
+	commitments[50] = tmp
+	// binding nonce commitment for signer 81 is an invalid curve point
+	commitments[80].bindingNonceCommitment = &Point{big.NewInt(100), big.NewInt(200)}
+	// hiding nonce commitment for signer 100 is an invalid curve point
+	commitments[99].hidingNonceCommitment = &Point{big.NewInt(300), big.NewInt(400)}
+
+	signer := signers[0]
+
+	validationErrors := signer.validateGroupCommitment(commitments)
+
+	expectedError1 := "commitments not sorted in ascending order: commitments[31].signerIndex=51, commitments[32].signerIndex=33"
+	expectedError2 := "commitments not sorted in ascending order: commitments[49].signerIndex=50, commitments[50].signerIndex=32"
+	expectedError3 := "binding nonce commitment from signer [81] is not a valid non-identity point on the curve: [Point[X=0x64, Y=0xc8]]"
+	expectedError4 := "hiding nonce commitment from signer [100] is not a valid non-identity point on the curve: [Point[X=0x12c, Y=0x190]]"
+
+	testutils.AssertIntsEqual(t, "number of validation errors", 4, len(validationErrors))
+	testutils.AssertStringsEqual(t, "validation error #1", expectedError1, validationErrors[0].Error())
+	testutils.AssertStringsEqual(t, "validation error #2", expectedError2, validationErrors[1].Error())
+	testutils.AssertStringsEqual(t, "validation error #3", expectedError3, validationErrors[2].Error())
+	testutils.AssertStringsEqual(t, "validation error #4", expectedError4, validationErrors[3].Error())
+}
+
+func createSigners(t *testing.T) []*Signer {
+	var signers []*Signer
+
+	// TODO: replace dummy secret key share with something real
+	buf := make([]byte, 32)
+	_, err := rand.Read(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secretKeyShare := new(big.Int).SetBytes(buf)
+
+	for i := 1; i <= groupSize; i++ {
+		signer := &Signer{
+			ciphersuite:    ciphersuite,
+			signerIndex:    uint64(i),
+			secretKeyShare: secretKeyShare,
+		}
+
+		signers = append(signers, signer)
+	}
+
+	return signers
+}
+
+func executeRound1(t *testing.T, signers []*Signer) ([]*Nonce, []*NonceCommitment) {
+	var nonces []*Nonce
+	var commitments []*NonceCommitment
+
+	for _, signer := range signers {
+		n, c, err := signer.Round1()
+		if err != nil {
+			t.Fatal(t)
+		}
+
+		nonces = append(nonces, n)
+		commitments = append(commitments, c)
+	}
+
+	return nonces, commitments
+}

--- a/frost/signer_test.go
+++ b/frost/signer_test.go
@@ -2,6 +2,7 @@ package frost
 
 import (
 	"crypto/rand"
+	"encoding/hex"
 	"math/big"
 	"testing"
 
@@ -51,6 +52,74 @@ func TestValidateGroupCommitments_Errors(t *testing.T) {
 	testutils.AssertStringsEqual(t, "validation error #2", expectedError2, validationErrors[1].Error())
 	testutils.AssertStringsEqual(t, "validation error #3", expectedError3, validationErrors[2].Error())
 	testutils.AssertStringsEqual(t, "validation error #4", expectedError4, validationErrors[3].Error())
+}
+
+func TestEncodeGroupCommitments_ValidationError(t *testing.T) {
+	// just a basic test checking if encodeGroupCommitment calls the validation
+
+	signers := createSigners(t)
+	_, commitments := executeRound1(t, signers)
+	commitments[0].bindingNonceCommitment = &Point{big.NewInt(99), big.NewInt(88)}
+
+	signer := signers[1]
+
+	_, errs := signer.encodeGroupCommitment(commitments)
+	testutils.AssertIntsEqual(t, "number of validation errors", 1, len(errs))
+}
+
+func TestEncodeGroupCommitments(t *testing.T) {
+
+	hidingNonceCommitments := [][]string{
+		{"d01115d548e7561b15c38f004d734633687cf4419620095bc5b0f47070afe85a", "a9f34ffdc815e0d7a8b64537e17bd81579238c5dd9a86d526b051b13f4062327"}, // G*12
+		{"f28773c2d975288bc7d1d205c3748651b075fbc6610e58cddeeddf8f19405aa8", "ab0902e8d880a89758212eb65cdaf473a1a06da521fa91f29b5cb52db03ed81"},  // G*13
+		{"499fdf9e895e719cfd64e67f07d38e3226aa7b63678949e6e49b241a60e823e4", "cac2f6c4b54e855190f044e4a7b3d464464279c27a3f95bcc65f40d403a13f5b"}, // G*14
+	}
+
+	bindingNonceCommitments := [][]string{
+		{"136933174bc388a74ebd6746e13afe0eef5d66580c8e23d33464c342dc0080", "27015dc47dbfe781689f232541c0410560ac69c82044e8e5906e54680127ff92"},   // G*246
+		{"9e2158f0d7c0d5f26c3791efefa79597654e7a2b2464f52b1ee6c1347769ef57", "712fcdd1b9053f09003a3481fa7762e9ffd7c8ef35a38509e2fbf2629008373"},  // G*247
+		{"22213b78f3dcfbdfeb76cc1731c1ba318b2b0c32f081e206f50618fa7eaf5aa3", "dd81b694ec3a60bad2a203d8eedc863fe476add5cf7391740d86e5c8718a3051"}, //G*248
+	}
+
+	// note all data types occupy the same byte length and are left-padded, if necessary
+	expectedEncoded := "" +
+		"0000000000000001" + // signer[0] index
+		"04d01115d548e7561b15c38f004d734633687cf4419620095bc5b0f47070afe85aa9f34ffdc815e0d7a8b64537e17bd81579238c5dd9a86d526b051b13f4062327" + // hiding nonce [0]
+		"0400136933174bc388a74ebd6746e13afe0eef5d66580c8e23d33464c342dc008027015dc47dbfe781689f232541c0410560ac69c82044e8e5906e54680127ff92" + // binding nonce [0]
+		"0000000000000002" + // signer [1] index
+		"04f28773c2d975288bc7d1d205c3748651b075fbc6610e58cddeeddf8f19405aa80ab0902e8d880a89758212eb65cdaf473a1a06da521fa91f29b5cb52db03ed81" + // hiding nonce [1]
+		"049e2158f0d7c0d5f26c3791efefa79597654e7a2b2464f52b1ee6c1347769ef570712fcdd1b9053f09003a3481fa7762e9ffd7c8ef35a38509e2fbf2629008373" + // binding nonce [1]
+		"0000000000000003" + // signer [2] index
+		"04499fdf9e895e719cfd64e67f07d38e3226aa7b63678949e6e49b241a60e823e4cac2f6c4b54e855190f044e4a7b3d464464279c27a3f95bcc65f40d403a13f5b" + // hiding nonce [2]
+		"0422213b78f3dcfbdfeb76cc1731c1ba318b2b0c32f081e206f50618fa7eaf5aa3dd81b694ec3a60bad2a203d8eedc863fe476add5cf7391740d86e5c8718a3051" // binding nonce [2]
+
+	var commitments []*NonceCommitment
+	for i, c := range hidingNonceCommitments {
+		hnx, _ := new(big.Int).SetString(c[0], 16)
+		hny, _ := new(big.Int).SetString(c[1], 16)
+
+		bnx, _ := new(big.Int).SetString(bindingNonceCommitments[i][0], 16)
+		bny, _ := new(big.Int).SetString(bindingNonceCommitments[i][1], 16)
+
+		commitments = append(commitments, &NonceCommitment{
+			signerIndex:            uint64(i + 1),
+			hidingNonceCommitment:  &Point{hnx, hny},
+			bindingNonceCommitment: &Point{bnx, bny},
+		})
+	}
+
+	signer := createSigners(t)[0]
+	encoded, errs := signer.encodeGroupCommitment(commitments)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected validation errors: [%v]", errs)
+	}
+
+	testutils.AssertStringsEqual(
+		t,
+		"encoded data",
+		expectedEncoded,
+		hex.EncodeToString(encoded),
+	)
 }
 
 func createSigners(t *testing.T) []*Signer {

--- a/internal/testutils/testutils.go
+++ b/internal/testutils/testutils.go
@@ -27,6 +27,19 @@ func AssertBigIntsEqual(t *testing.T, description string, expected *big.Int, act
 	}
 }
 
+// AssertIntsEqual checks if two integers are equal. If not, it reports a test
+// failure.
+func AssertIntsEqual(t *testing.T, description string, expected int, actual int) {
+	if expected != actual {
+		t.Errorf(
+			"unexpected %s\nexpected: %v\nactual:   %v\n",
+			description,
+			expected,
+			actual,
+		)
+	}
+}
+
 // AssertBytesEqual checks if the two bytes array are equal. If not, it reports
 // a test failure.
 func AssertBytesEqual(t *testing.T, expectedBytes []byte, actualBytes []byte) {

--- a/internal/testutils/testutils.go
+++ b/internal/testutils/testutils.go
@@ -50,6 +50,19 @@ func AssertBytesEqual(t *testing.T, expectedBytes []byte, actualBytes []byte) {
 	}
 }
 
+// AssertStringsEqual checks if two strings are equal. If not, it reports a test
+// failure.
+func AssertStringsEqual(t *testing.T, description string, expected string, actual string) {
+	if expected != actual {
+		t.Errorf(
+			"unexpected %s\nexpected: %s\nactual:   %s\n",
+			description,
+			expected,
+			actual,
+		)
+	}
+}
+
 func testBytesEqual(expectedBytes []byte, actualBytes []byte) error {
 	minLen := len(expectedBytes)
 	diffCount := 0


### PR DESCRIPTION
This PR implements code for serializing elliptic curve points and implements FROST group commitment encoding needed in round 2 of the protocol.

The functions serializing and deserializing points expect to always return and accept slice of the same length that is specific to the curve implementation. This allows the FROST group commitment encoding to expect commitments always have a predictable length.

