### PR TITLE
Compute bindings factors and group commitment

### DIFF
--- a/frost/bip340.go
+++ b/frost/bip340.go
@@ -61,18 +61,22 @@ func (b *Bip340Curve) SerializePoint(p *Point) []byte {
 }
 
 // DeserializePoint deserializes byte slice to an elliptic curve point. The
-// byte slice length must be equal to SerializedPointLength(). Otherwise,
+// byte slice length must be equal to SerializedPointLength(). The deserialized
+// point must be a valid, non-identity point lying on the curve. Otherwise,
 // the function returns nil.
 func (b *Bip340Curve) DeserializePoint(bytes []byte) *Point {
-
-	// TODO: validate if point is on the curve
-
 	x, y := b.Unmarshal(bytes)
 	if x == nil || y == nil {
 		return nil
 	}
 
-	return &Point{x, y}
+	point := &Point{x, y}
+
+	if !b.IsNotIdentity(point) {
+		return nil
+	}
+
+	return point
 }
 
 // H1 is the implementation of H1(m) function from [FROST].

--- a/frost/bip340.go
+++ b/frost/bip340.go
@@ -60,9 +60,9 @@ func (bc *Bip340Curve) Identity() *Point {
 	return &Point{big.NewInt(0), big.NewInt(0)}
 }
 
-// IsNotIdentity validates if the point lies on the curve and is not an identity
-// element.
-func (bc *Bip340Curve) IsNotIdentity(p *Point) bool {
+// IsPointOnCurve validates if the point lies on the curve and is not an
+// identity element.
+func (bc *Bip340Curve) IsPointOnCurve(p *Point) bool {
 	return bc.IsOnCurve(p.X, p.Y)
 }
 
@@ -94,7 +94,7 @@ func (b *Bip340Curve) DeserializePoint(bytes []byte) *Point {
 
 	point := &Point{x, y}
 
-	if !b.IsNotIdentity(point) {
+	if !b.IsPointOnCurve(point) {
 		return nil
 	}
 

--- a/frost/bip340.go
+++ b/frost/bip340.go
@@ -33,9 +33,31 @@ type Bip340Curve struct {
 
 // EcBaseMul returns k*G, where G is the base point of the group.
 func (bc *Bip340Curve) EcBaseMul(k *big.Int) *Point {
-	sp := new(big.Int).Mod(k, bc.N)
-	gs_x, gs_y := bc.ScalarBaseMult(sp.Bytes())
-	return &Point{gs_x, gs_y}
+	kmod := new(big.Int).Mod(k, bc.N)
+	x, y := bc.ScalarBaseMult(kmod.Bytes())
+	return &Point{x, y}
+}
+
+// EcMul returns k*P where P is the point provided as a parameter and k is
+// as integer.
+func (bc *Bip340Curve) EcMul(p *Point, k *big.Int) *Point {
+	kmod := new(big.Int).Mod(k, bc.N)
+	x, y := bc.ScalarMult(p.X, p.Y, kmod.Bytes())
+	return &Point{x, y}
+}
+
+// EcAdd returns the sum of two elliptic curve points.
+func (bc *Bip340Curve) EcAdd(a *Point, b *Point) *Point {
+	x, y := bc.Add(a.X, a.Y, b.X, b.Y)
+	return &Point{x, y}
+}
+
+// Identity returns elliptic curve identity element.
+func (bc *Bip340Curve) Identity() *Point {
+	// For elliptic curves, the identity is the point at infinity.
+	// For secp256k1 we pick a conventional representation as (0,0) in cartesian
+	// coordinates. This is fine because 0,0 does not lie on the secp256k1 curve.
+	return &Point{big.NewInt(0), big.NewInt(0)}
 }
 
 // IsNotIdentity validates if the point lies on the curve and is not an identity

--- a/frost/bip340_test.go
+++ b/frost/bip340_test.go
@@ -57,6 +57,9 @@ func TestBip340CurveDeserialize(t *testing.T) {
 		"one more than expected": {
 			input: append(serialized, 0x1),
 		},
+		"not on the curve": {
+			input: curve.SerializePoint(&Point{big.NewInt(1), big.NewInt(2)}),
+		},
 	}
 
 	for testName, test := range tests {

--- a/frost/bip340_test.go
+++ b/frost/bip340_test.go
@@ -8,6 +8,59 @@ import (
 	"threshold.network/roast/internal/testutils"
 )
 
+func TestBip340CurveEcBaseMul(t *testing.T) {
+	curve := NewBip340Ciphersuite().Curve()
+	point := curve.EcBaseMul(big.NewInt(10))
+
+	expectedX := "72488970228380509287422715226575535698893157273063074627791787432852706183111"
+	expectedY := "62070622898698443831883535403436258712770888294397026493185421712108624767191"
+
+	testutils.AssertStringsEqual(t, "X coordinate", expectedX, point.X.String())
+	testutils.AssertStringsEqual(t, "Y coordinate", expectedY, point.Y.String())
+}
+
+func TestBip340CurveEcMul(t *testing.T) {
+	curve := NewBip340Ciphersuite().Curve()
+	point := curve.EcBaseMul(big.NewInt(10))
+	result := curve.EcMul(point, big.NewInt(5))
+
+	expectedX := "18752372355191540835222161239240920883340654532661984440989362140194381601434"
+	expectedY := "88478450163343634110113046083156231725329016889379853417393465962619872936244"
+
+	testutils.AssertStringsEqual(t, "X coordinate", expectedX, result.X.String())
+	testutils.AssertStringsEqual(t, "Y coordinate", expectedY, result.Y.String())
+}
+
+func TestBip340CurveEcAdd(t *testing.T) {
+	curve := NewBip340Ciphersuite().Curve()
+	point1 := curve.EcBaseMul(big.NewInt(10))
+	point2 := curve.EcBaseMul(big.NewInt(20))
+	result := curve.EcAdd(point1, point2)
+
+	expectedX := "49378132684229722274313556995573891527709373183446262831552359577455015004672"
+	expectedY := "78123232289538034746933569305416412888858560602643272431489024958214987548923"
+
+	testutils.AssertStringsEqual(t, "X coordinate", expectedX, result.X.String())
+	testutils.AssertStringsEqual(t, "Y coordinate", expectedY, result.Y.String())
+}
+
+func TestBip340CurveEcAdd_Identity(t *testing.T) {
+	curve := NewBip340Ciphersuite().Curve()
+	point := curve.EcBaseMul(big.NewInt(10))
+	identity := curve.Identity()
+
+	result1 := curve.EcAdd(point, identity)
+	result2 := curve.EcAdd(identity, point)
+
+	expectedX := "72488970228380509287422715226575535698893157273063074627791787432852706183111"
+	expectedY := "62070622898698443831883535403436258712770888294397026493185421712108624767191"
+
+	testutils.AssertStringsEqual(t, "X coordinate", expectedX, result1.X.String())
+	testutils.AssertStringsEqual(t, "Y coordinate", expectedY, result1.Y.String())
+	testutils.AssertStringsEqual(t, "X coordinate", expectedX, result2.X.String())
+	testutils.AssertStringsEqual(t, "Y coordinate", expectedY, result2.Y.String())
+}
+
 func TestBip340CurveSerializedPointLength(t *testing.T) {
 	curve := NewBip340Ciphersuite().Curve()
 
@@ -59,6 +112,9 @@ func TestBip340CurveDeserialize(t *testing.T) {
 		},
 		"not on the curve": {
 			input: curve.SerializePoint(&Point{big.NewInt(1), big.NewInt(2)}),
+		},
+		"identity element": {
+			input: curve.SerializePoint(curve.Identity()),
 		},
 	}
 

--- a/frost/ciphersuite.go
+++ b/frost/ciphersuite.go
@@ -46,9 +46,18 @@ type Curve interface {
 	// Identity returns elliptic curve identity element.
 	Identity() *Point
 
-	// IsNotIdentity validates if the point lies on the curve and is not an
+	// IsPointOnCurve validates if the point lies on the curve and is not an
 	// identity element.
-	IsNotIdentity(*Point) bool
+	//
+	// [FROST] requires to validate if we are dealing with a valid element of
+	// the group and that element is a non-identity element.
+	// For elliptic curve cryptography, we do not have an identity element but
+	// we take the point at infinity as an identity element. The point at
+	// infinity is an extra point O and it is not on the curve. In our case it
+	// is enough to validate if the point is on the curve. This validation will
+	// satisfy [FROST] requirements of a valid, non-identity element of the
+	// group.
+	IsPointOnCurve(*Point) bool
 
 	// SerializedPointLength returns the byte length of a serialized curve point.
 	// The value is specific to the implementation. It is expected that the

--- a/frost/ciphersuite.go
+++ b/frost/ciphersuite.go
@@ -36,6 +36,16 @@ type Curve interface {
 	// EcBaseMul returns k*G, where G is the base point of the group.
 	EcBaseMul(*big.Int) *Point
 
+	// EcMul returns k*P where P is the point provided as a parameter and k is
+	// as integer.
+	EcMul(*Point, *big.Int) *Point
+
+	// EcAdd returns the sum of two elliptic curve points.
+	EcAdd(*Point, *Point) *Point
+
+	// Identity returns elliptic curve identity element.
+	Identity() *Point
+
 	// IsNotIdentity validates if the point lies on the curve and is not an
 	// identity element.
 	IsNotIdentity(*Point) bool

--- a/frost/signer.go
+++ b/frost/signer.go
@@ -106,7 +106,7 @@ func (s *Signer) Round2(message []byte, commitments []*NonceCommitment) (*big.In
 // validateGroupCommitments is a helper function used internally by
 // encodeGroupCommitment to validate the group commitments. Two validations are
 // done:
-// - None of the commitments is the identity element of the curve.
+// - None of the commitments is a point not lying on the curve.
 // - The list of commitments is sorted in ascending order by signer identifier.
 func (s *Signer) validateGroupCommitments(commitments []*NonceCommitment) []error {
 	// From [FROST]:
@@ -152,7 +152,7 @@ func (s *Signer) validateGroupCommitments(commitments []*NonceCommitment) []erro
 
 		lastSignerIndex = c.signerIndex
 
-		if !curve.IsNotIdentity(c.bindingNonceCommitment) {
+		if !curve.IsPointOnCurve(c.bindingNonceCommitment) {
 			errors = append(errors, fmt.Errorf(
 				"binding nonce commitment from signer [%v] is not a valid "+
 					"non-identity point on the curve: [%s]",
@@ -161,7 +161,7 @@ func (s *Signer) validateGroupCommitments(commitments []*NonceCommitment) []erro
 			))
 		}
 
-		if !curve.IsNotIdentity(c.hidingNonceCommitment) {
+		if !curve.IsPointOnCurve(c.hidingNonceCommitment) {
 			errors = append(errors, fmt.Errorf(
 				"hiding nonce commitment from signer [%v] is not a valid "+
 					"non-identity point on the curve: [%s]",

--- a/frost/signer.go
+++ b/frost/signer.go
@@ -3,6 +3,7 @@ package frost
 import (
 	"crypto/rand"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"math/big"
 )
@@ -88,77 +89,21 @@ func (s *Signer) generateNonce(secret []byte) (*big.Int, error) {
 	return s.ciphersuite.H3(b, secret), nil
 }
 
-// encodeGroupCommitment implements def encode_group_commitment_list(commitment_list)
-// function from [FROST], as defined in section 4.3.  List Operations.
-//
-// The function calling encodeGroupCommitment must ensure a valid number of
-// commitments have been received.
-func (s *Signer) encodeGroupCommitment(commitments []*NonceCommitment) ([]byte, []error) {
-	// From [FROST]:
-	//
-	// 4.3.  List Operations
-	//
-	//   This section describes helper functions that work on lists of values
-	//   produced during the FROST protocol.  The following function encodes a
-	//   list of participant commitments into a byte string for use in the
-	//   FROST protocol.
-	//
-	//   Inputs:
-	//     - commitment_list = [(i, hiding_nonce_commitment_i,
-	//       binding_nonce_commitment_i), ...], a list of commitments issued by
-	//       each participant, where each element in the list indicates a
-	//       NonZeroScalar identifier i and two commitment Element values
-	//       (hiding_nonce_commitment_i, binding_nonce_commitment_i). This list
-	//       MUST be sorted in ascending order by identifier.
-	//
-	//   Outputs:
-	//     - encoded_group_commitment, the serialized representation of
-	//       commitment_list, a byte string.
-	//
-	//   def encode_group_commitment_list(commitment_list):
-
-	// perform validations early to extract complexity out of the loop
-	// constructing encoded_group_commitment
-	validationErrors := s.validateGroupCommitment(commitments)
+func (s *Signer) Round2(message []byte, commitments []*NonceCommitment) (*big.Int, error) {
+	validationErrors := s.validateGroupCommitments(commitments)
 	if len(validationErrors) != 0 {
-		return nil, validationErrors
+		return nil, errors.Join(validationErrors...)
 	}
 
-	curve := s.ciphersuite.Curve()
-	ecPointLength := curve.SerializedPointLength()
-
-	// preallocate the necessary space to avoid waste:
-	// 8 bytes for signerIndex (uint64)
-	// ecPointLength for hidingNonceCommitment
-	// ecPointLength for bindingNonceCommitment
-	b := make([]byte, 0, (8+2*ecPointLength)*len(commitments))
-
-	// encoded_group_commitment = nil
-	// for (identifier, hiding_nonce_commitment,
-	//      binding_nonce_commitment) in commitment_list:
-	for _, c := range commitments {
-		// encoded_commitment = (
-		//     G.SerializeScalar(identifier) ||
-		//     G.SerializeElement(hiding_nonce_commitment) ||
-		//     G.SerializeElement(binding_nonce_commitment))
-		// encoded_group_commitment = (
-		//     encoded_group_commitment ||
-		//     encoded_commitment)
-		b = binary.BigEndian.AppendUint64(b, c.signerIndex)
-		b = append(b, curve.SerializePoint(c.hidingNonceCommitment)...)
-		b = append(b, curve.SerializePoint(c.bindingNonceCommitment)...)
-	}
-
-	// return encoded_group_commitment
-	return b, nil
+	return nil, nil // TODO: return signature share
 }
 
-// validateGroupCommitment is a helper function used internally by
+// validateGroupCommitments is a helper function used internally by
 // encodeGroupCommitment to validate the group commitments. Two validations are
 // done:
 // - None of the commitments is the identity element of the curve.
 // - The list of commitments is sorted in ascending order by signer identifier.
-func (s *Signer) validateGroupCommitment(commitments []*NonceCommitment) []error {
+func (s *Signer) validateGroupCommitments(commitments []*NonceCommitment) []error {
 	// From [FROST]:
 	//
 	// 3.1 Prime-Order Group
@@ -222,4 +167,65 @@ func (s *Signer) validateGroupCommitment(commitments []*NonceCommitment) []error
 	}
 
 	return errors
+}
+
+// encodeGroupCommitment implements def encode_group_commitment_list(commitment_list)
+// function from [FROST], as defined in section 4.3.  List Operations.
+//
+// The function calling encodeGroupCommitment must ensure a valid number of
+// commitments have been received and call validateGroupCommitment to validate
+// the received commitments.
+func (s *Signer) encodeGroupCommitment(
+	commitments []*NonceCommitment,
+) ([]byte, []error) {
+	// From [FROST]:
+	//
+	// 4.3.  List Operations
+	//
+	//   This section describes helper functions that work on lists of values
+	//   produced during the FROST protocol.  The following function encodes a
+	//   list of participant commitments into a byte string for use in the
+	//   FROST protocol.
+	//
+	//   Inputs:
+	//     - commitment_list = [(i, hiding_nonce_commitment_i,
+	//       binding_nonce_commitment_i), ...], a list of commitments issued by
+	//       each participant, where each element in the list indicates a
+	//       NonZeroScalar identifier i and two commitment Element values
+	//       (hiding_nonce_commitment_i, binding_nonce_commitment_i). This list
+	//       MUST be sorted in ascending order by identifier.
+	//
+	//   Outputs:
+	//     - encoded_group_commitment, the serialized representation of
+	//       commitment_list, a byte string.
+	//
+	//   def encode_group_commitment_list(commitment_list):
+
+	curve := s.ciphersuite.Curve()
+	ecPointLength := curve.SerializedPointLength()
+
+	// preallocate the necessary space to avoid waste:
+	// 8 bytes for signerIndex (uint64)
+	// ecPointLength for hidingNonceCommitment
+	// ecPointLength for bindingNonceCommitment
+	b := make([]byte, 0, (8+2*ecPointLength)*len(commitments))
+
+	// encoded_group_commitment = nil
+	// for (identifier, hiding_nonce_commitment,
+	//      binding_nonce_commitment) in commitment_list:
+	for _, c := range commitments {
+		// encoded_commitment = (
+		//     G.SerializeScalar(identifier) ||
+		//     G.SerializeElement(hiding_nonce_commitment) ||
+		//     G.SerializeElement(binding_nonce_commitment))
+		// encoded_group_commitment = (
+		//     encoded_group_commitment ||
+		//     encoded_commitment)
+		b = binary.BigEndian.AppendUint64(b, c.signerIndex)
+		b = append(b, curve.SerializePoint(c.hidingNonceCommitment)...)
+		b = append(b, curve.SerializePoint(c.bindingNonceCommitment)...)
+	}
+
+	// return encoded_group_commitment
+	return b, nil
 }

--- a/frost/signer.go
+++ b/frost/signer.go
@@ -225,6 +225,8 @@ func (s *Signer) computeBindingFactors(
 	// binding_factor_list = []
 	bindingFactors := make(map[uint64]*big.Int, len(commitments))
 
+	// for (identifier, hiding_nonce_commitment,
+	//      binding_nonce_commitment) in commitment_list:
 	for _, commitment := range commitments {
 		// rho_input = rho_input_prefix || G.SerializeScalar(identifier)
 		rhoInput := make([]byte, len(rhoInputPrefix)+8)

--- a/frost/signer_test.go
+++ b/frost/signer_test.go
@@ -113,10 +113,7 @@ func TestEncodeGroupCommitments(t *testing.T) {
 	}
 
 	signer := createSigners(t)[0]
-	encoded, errs := signer.encodeGroupCommitment(commitments)
-	if len(errs) != 0 {
-		t.Fatalf("unexpected validation errors: [%v]", errs)
-	}
+	encoded := signer.encodeGroupCommitment(commitments)
 
 	testutils.AssertStringsEqual(
 		t,

--- a/frost/signer_test.go
+++ b/frost/signer_test.go
@@ -72,7 +72,6 @@ func TestValidateGroupCommitments_Errors(t *testing.T) {
 }
 
 func TestEncodeGroupCommitments(t *testing.T) {
-
 	hidingNonceCommitments := [][]string{
 		{"d01115d548e7561b15c38f004d734633687cf4419620095bc5b0f47070afe85a", "a9f34ffdc815e0d7a8b64537e17bd81579238c5dd9a86d526b051b13f4062327"}, // G*12
 		{"f28773c2d975288bc7d1d205c3748651b075fbc6610e58cddeeddf8f19405aa8", "ab0902e8d880a89758212eb65cdaf473a1a06da521fa91f29b5cb52db03ed81"},  // G*13

--- a/frost/signer_test.go
+++ b/frost/signer_test.go
@@ -12,13 +12,30 @@ import (
 var ciphersuite = NewBip340Ciphersuite()
 var groupSize = 100
 
-func TestValidateGroupCommitment(t *testing.T) {
+func TestRound2_ValidationError(t *testing.T) {
+	// just a basic test checking if Round2 calls validateGroupCommitments
+	signers := createSigners(t)
+	_, commitments := executeRound1(t, signers)
+	commitments[0].bindingNonceCommitment = &Point{big.NewInt(99), big.NewInt(88)}
+
+	signer := signers[1]
+
+	_, err := signer.Round2([]byte("dummy"), commitments)
+	if err == nil {
+		t.Fatalf("expected a non-nil error")
+	}
+	// assert if this is indeed a validation error
+	expectedError := "binding nonce commitment from signer [1] is not a valid non-identity point on the curve: [Point[X=0x63, Y=0x58]]"
+	testutils.AssertStringsEqual(t, "validation error", expectedError, err.Error())
+}
+
+func TestValidateGroupCommitments(t *testing.T) {
 	signers := createSigners(t)
 	_, commitments := executeRound1(t, signers)
 
 	signer := signers[0]
 
-	validationErrors := signer.validateGroupCommitment(commitments)
+	validationErrors := signer.validateGroupCommitments(commitments)
 	testutils.AssertIntsEqual(t, "number of validation errors", 0, len(validationErrors))
 }
 
@@ -40,7 +57,7 @@ func TestValidateGroupCommitments_Errors(t *testing.T) {
 
 	signer := signers[0]
 
-	validationErrors := signer.validateGroupCommitment(commitments)
+	validationErrors := signer.validateGroupCommitments(commitments)
 
 	expectedError1 := "commitments not sorted in ascending order: commitments[31].signerIndex=51, commitments[32].signerIndex=33"
 	expectedError2 := "commitments not sorted in ascending order: commitments[49].signerIndex=50, commitments[50].signerIndex=32"
@@ -52,19 +69,6 @@ func TestValidateGroupCommitments_Errors(t *testing.T) {
 	testutils.AssertStringsEqual(t, "validation error #2", expectedError2, validationErrors[1].Error())
 	testutils.AssertStringsEqual(t, "validation error #3", expectedError3, validationErrors[2].Error())
 	testutils.AssertStringsEqual(t, "validation error #4", expectedError4, validationErrors[3].Error())
-}
-
-func TestEncodeGroupCommitments_ValidationError(t *testing.T) {
-	// just a basic test checking if encodeGroupCommitment calls the validation
-
-	signers := createSigners(t)
-	_, commitments := executeRound1(t, signers)
-	commitments[0].bindingNonceCommitment = &Point{big.NewInt(99), big.NewInt(88)}
-
-	signer := signers[1]
-
-	_, errs := signer.encodeGroupCommitment(commitments)
-	testutils.AssertIntsEqual(t, "number of validation errors", 1, len(errs))
 }
 
 func TestEncodeGroupCommitments(t *testing.T) {


### PR DESCRIPTION
This PR introduces `computeBindingFactors` and `computeGroupCommitment` based on @eth-r's prototype implementation. The code is almost 1:1 as in the prototype with the exception that we use a map to represent binding factors. This way we can eliminate `binding_factor_for_participant` search.

The `Deserialize` function of the elliptic curve point BIP-340 implementation validates now if the point is on the curve. The validation of group commitments has been moved to the beginning of round two.

Worth noting, `computeBindingFactors` and `computeGroupCommitment` lack unit tests. It is hard to come up with unit tests that wouldn't replicate implementation or work on hardcoded numbers that don't make a lot of sense alone, out of context. I am planning to cover round two in unit tests as a whole piece.