### PR TITLE
Implemented deriveInterpolatingValue function

### DIFF
--- a/frost/bip340.go
+++ b/frost/bip340.go
@@ -60,7 +60,7 @@ func (bc *Bip340Curve) Identity() *Point {
 	return &Point{big.NewInt(0), big.NewInt(0)}
 }
 
-// Order returns the order of the elliptic curve.
+// Order returns the order of the group produced by the elliptic curve generator.
 func (bc *Bip340Curve) Order() *big.Int {
 	return new(big.Int).Set(bc.N)
 }

--- a/frost/bip340.go
+++ b/frost/bip340.go
@@ -60,6 +60,11 @@ func (bc *Bip340Curve) Identity() *Point {
 	return &Point{big.NewInt(0), big.NewInt(0)}
 }
 
+// Order returns the order of the elliptic curve.
+func (bc *Bip340Curve) Order() *big.Int {
+	return new(big.Int).Set(bc.N)
+}
+
 // IsPointOnCurve validates if the point lies on the curve and is not an
 // identity element.
 func (bc *Bip340Curve) IsPointOnCurve(p *Point) bool {

--- a/frost/ciphersuite.go
+++ b/frost/ciphersuite.go
@@ -46,6 +46,9 @@ type Curve interface {
 	// Identity returns elliptic curve identity element.
 	Identity() *Point
 
+	// Order returns the order of the elliptic curve.
+	Order() *big.Int
+
 	// IsPointOnCurve validates if the point lies on the curve and is not an
 	// identity element.
 	//

--- a/frost/ciphersuite.go
+++ b/frost/ciphersuite.go
@@ -46,7 +46,8 @@ type Curve interface {
 	// Identity returns elliptic curve identity element.
 	Identity() *Point
 
-	// Order returns the order of the elliptic curve.
+	// Order returns the order of the group produced by the elliptic curve
+	// generator.
 	Order() *big.Int
 
 	// IsPointOnCurve validates if the point lies on the curve and is not an

--- a/frost/signer_test.go
+++ b/frost/signer_test.go
@@ -43,9 +43,11 @@ func TestValidateGroupCommitments_Errors(t *testing.T) {
 	signers := createSigners(t)
 	_, commitments := executeRound1(t, signers)
 
-	tmp := commitments[31]
+	// duplicate commitment from signer 5 at positions 4 and 5
+	commitments[5] = commitments[4]
 	// at the position where we'd expect a commitment from signer 32 we have
 	// a commitment from signer 51
+	tmp := commitments[31]
 	commitments[31] = commitments[50]
 	// at the position where we'd expect a commitment from signer 51 we have
 	// a commitment from signer 32
@@ -59,16 +61,18 @@ func TestValidateGroupCommitments_Errors(t *testing.T) {
 
 	validationErrors := signer.validateGroupCommitments(commitments)
 
-	expectedError1 := "commitments not sorted in ascending order: commitments[31].signerIndex=51, commitments[32].signerIndex=33"
-	expectedError2 := "commitments not sorted in ascending order: commitments[49].signerIndex=50, commitments[50].signerIndex=32"
-	expectedError3 := "binding nonce commitment from signer [81] is not a valid non-identity point on the curve: [Point[X=0x64, Y=0xc8]]"
-	expectedError4 := "hiding nonce commitment from signer [100] is not a valid non-identity point on the curve: [Point[X=0x12c, Y=0x190]]"
+	expectedError1 := "commitments not sorted in ascending order: commitments[4].signerIndex=5, commitments[5].signerIndex=5"
+	expectedError2 := "commitments not sorted in ascending order: commitments[31].signerIndex=51, commitments[32].signerIndex=33"
+	expectedError3 := "commitments not sorted in ascending order: commitments[49].signerIndex=50, commitments[50].signerIndex=32"
+	expectedError4 := "binding nonce commitment from signer [81] is not a valid non-identity point on the curve: [Point[X=0x64, Y=0xc8]]"
+	expectedError5 := "hiding nonce commitment from signer [100] is not a valid non-identity point on the curve: [Point[X=0x12c, Y=0x190]]"
 
-	testutils.AssertIntsEqual(t, "number of validation errors", 4, len(validationErrors))
+	testutils.AssertIntsEqual(t, "number of validation errors", 5, len(validationErrors))
 	testutils.AssertStringsEqual(t, "validation error #1", expectedError1, validationErrors[0].Error())
 	testutils.AssertStringsEqual(t, "validation error #2", expectedError2, validationErrors[1].Error())
 	testutils.AssertStringsEqual(t, "validation error #3", expectedError3, validationErrors[2].Error())
 	testutils.AssertStringsEqual(t, "validation error #4", expectedError4, validationErrors[3].Error())
+	testutils.AssertStringsEqual(t, "validation error #5", expectedError5, validationErrors[4].Error())
 }
 
 func TestEncodeGroupCommitments(t *testing.T) {


### PR DESCRIPTION
deriveInterpolatingValue implements `def derive_interpolating_value(L, x_i)` function from [FROST], as defined in section 4.2 Polynomials.

deriveInterpolatingValue is a simplified version of the algorithm for computing Lagrange coefficient given we only care about the value f(0) instead of reconstructing the entire polynomial.

`L` is the list of the indices of the members of the particular group. `xi` is the index of the participant `i`.

The function is identical as in @eth-r's prototype except that we return errors instead of panicking. Unit tests covering the function and explaining how interpolating value is calculated were added.