### PR TITLE
Aggregate signature shares

### DIFF
--- a/frost/bip340.go
+++ b/frost/bip340.go
@@ -197,6 +197,22 @@ func (b *Bip340Ciphersuite) hash(tag, msg []byte) [32]byte {
 	return hashed
 }
 
+// EncodePoint encodes the given elliptic curve point to a byte slice in a way
+// that is *specific* to [BIP-340] needs.
+//
+// This function yields a different result than SerializePoint function from the
+// Curve interface. The SerializePoint serializes both X and Y coordinates,
+// while EncodePoint serializes just X coordinate, as it is expected by
+// [BIP-340] for the challenge computation. The way SerializePoint works allows
+// to avoid computing Y coordinate manually when exchanging data. The way
+// EncodePoint works is dictated by [BIP-340] specification.
+func (b *Bip340Ciphersuite) EncodePoint(point *Point) []byte {
+	xMod := new(big.Int).Mod(point.X, b.curve.P)
+	xbs := make([]byte, 32)
+	xMod.FillBytes(xbs)
+	return xbs
+}
+
 // concat performs a concatenation of byte slices without the modification of
 // the slices passed as parameters. A brand new slice instance is always
 // returned from the function.

--- a/frost/bip340.go
+++ b/frost/bip340.go
@@ -52,6 +52,12 @@ func (bc *Bip340Curve) EcAdd(a *Point, b *Point) *Point {
 	return &Point{x, y}
 }
 
+// EcSub returns the subtraction of two elliptic curve points.
+func (bc *Bip340Curve) EcSub(a *Point, b *Point) *Point {
+	bNeg := &Point{b.X, new(big.Int).Neg(b.Y)}
+	return bc.EcAdd(a, bNeg)
+}
+
 // Identity returns elliptic curve identity element.
 func (bc *Bip340Curve) Identity() *Point {
 	// For elliptic curves, the identity is the point at infinity.

--- a/frost/bip340_test.go
+++ b/frost/bip340_test.go
@@ -44,6 +44,19 @@ func TestBip340CurveEcAdd(t *testing.T) {
 	testutils.AssertStringsEqual(t, "Y coordinate", expectedY, result.Y.String())
 }
 
+func TestBip340CurveEcSub(t *testing.T) {
+	curve := NewBip340Ciphersuite().Curve()
+	point1 := curve.EcBaseMul(big.NewInt(30))
+	point2 := curve.EcBaseMul(big.NewInt(5))
+	result := curve.EcSub(point1, point2)
+
+	expectedX := "66165162229742397718677620062386824252848999675912518712054484685772795754260"
+	expectedY := "52018513869565587577673992057861898728543589604141463438466108080111932355586"
+
+	testutils.AssertStringsEqual(t, "X coordinate", expectedX, result.X.String())
+	testutils.AssertStringsEqual(t, "Y coordinate", expectedY, result.Y.String())
+}
+
 func TestBip340CurveEcAdd_Identity(t *testing.T) {
 	curve := NewBip340Ciphersuite().Curve()
 	point := curve.EcBaseMul(big.NewInt(10))

--- a/frost/ciphersuite.go
+++ b/frost/ciphersuite.go
@@ -94,3 +94,12 @@ type Point struct {
 func (p *Point) String() string {
 	return fmt.Sprintf("Point[X=0x%v, Y=0x%v]", p.X.Text(16), p.Y.Text(16))
 }
+
+// Signature represents a Schnorr signature produced by [FROST] protocol as
+// a result of the signature share aggregation. Note that the signature produced
+// by the signature share aggregation in [FROST] may not be valid if there are
+// malicious signers present.
+type Signature struct {
+	R *Point   // R in [FROST] appendix C
+	Z *big.Int // z in [FROST] appendix C
+}

--- a/frost/ciphersuite.go
+++ b/frost/ciphersuite.go
@@ -13,6 +13,18 @@ import (
 type Ciphersuite interface {
 	Hashing
 	Curve() Curve
+
+	// EncodePoint encodes the given elliptic curve point to a byte slice in
+	// a way that is *specific* to the given ciphersuite needs. This is
+	// especially important when calculating a signature challenge in [FROST].
+	//
+	// This function may yield a different result than SerializePoint function
+	// from the Curve interface. While the SerializePoint result should be
+	// considered an internal serialization that may be optimized for speed or
+	// data consistency, the EncodePoint result should be considered an external
+	// serialization, always reflecting the given ciphersuite's specification
+	// requirements.
+	EncodePoint(point *Point) []byte
 }
 
 // Hashing interface abstracts out hash functions implementations specific to the
@@ -22,6 +34,10 @@ type Ciphersuite interface {
 // generically written as H. Using H, [FROST] introduces distinct domain-separated
 // hashes, H1, H2, H3, H4, and H5. The details of H1, H2, H3, H4, and H5 vary
 // based on ciphersuite.
+//
+// Note that for some of those functions it may be important to use a specific
+// encoding of elliptic curve points depending on the ciphersuite being
+// implemented.
 type Hashing interface {
 	H1(m []byte) *big.Int
 	H2(m []byte, ms ...[]byte) *big.Int

--- a/frost/ciphersuite.go
+++ b/frost/ciphersuite.go
@@ -43,6 +43,9 @@ type Curve interface {
 	// EcAdd returns the sum of two elliptic curve points.
 	EcAdd(*Point, *Point) *Point
 
+	// EcSub returns the subtraction of two elliptic curve points.
+	EcSub(*Point, *Point) *Point
+
 	// Identity returns elliptic curve identity element.
 	Identity() *Point
 

--- a/frost/coordinator.go
+++ b/frost/coordinator.go
@@ -1,0 +1,78 @@
+package frost
+
+import (
+	"errors"
+	"math/big"
+)
+
+// Coordinator represents a coordinator of the [FROST] signing protocol.
+type Coordinator struct {
+	Participant
+}
+
+// Aggregate implements Signature Share Aggregation from [FROST], section
+// 5.3. Signature Share Aggregation.
+func (c *Coordinator) Aggregate(
+	message []byte,
+	commitments []*NonceCommitment,
+	signatureShares []*big.Int,
+) (*Point, *big.Int, error) {
+	// From [FROST]:
+	//
+	// 5.3.  Signature Share Aggregation
+	//
+	//   After participants perform round two and send their signature shares
+	//   to the Coordinator, the Coordinator aggregates each share to produce
+	//   a final signature. Before aggregating, the Coordinator MUST validate
+	//   each signature share using DeserializeScalar. If validation fails,
+	//   the Coordinator MUST abort the protocol as the resulting signature
+	//   will be invalid.  If all signature shares are valid, the Coordinator
+	//   aggregates them to produce the final signature using the following
+	//   procedure.
+	//
+	//   Inputs:
+	//    - commitment_list = [(i, hiding_nonce_commitment_i,
+	//      binding_nonce_commitment_i), ...], a list of commitments issued by
+	//      each participant, where each element in the list indicates a
+	//      NonZeroScalar identifier i and two commitment Element values
+	//      (hiding_nonce_commitment_i, binding_nonce_commitment_i). This list
+	//      MUST be sorted in ascending order by identifier.
+	//    - msg, the message to be signed, a byte string.
+	//    - group_public_key, public key corresponding to the group signing
+	//      key, an Element.
+	//    - sig_shares, a set of signature shares z_i, Scalar values, for each
+	//      participant, of length NUM_PARTICIPANTS, where
+	//      MIN_PARTICIPANTS <= NUM_PARTICIPANTS <= MAX_PARTICIPANTS.
+	//
+	//   Outputs:
+	//    - (R, z), a Schnorr signature consisting of an Element R and
+	//      Scalar z.
+
+	// TODO: validate the number of signature shares
+
+	validationErrors, _ := c.validateGroupCommitmentsBase(commitments)
+	if len(validationErrors) != 0 {
+		return nil, nil, errors.Join(validationErrors...)
+	}
+
+	// binding_factor_list = compute_binding_factors(group_public_key, commitment_list, msg)
+	bindingFactors := c.computeBindingFactors(message, commitments)
+
+	// group_commitment = compute_group_commitment(commitment_list, binding_factor_list)
+	groupCommitment := c.computeGroupCommitment(commitments, bindingFactors)
+
+	curve := c.ciphersuite.Curve()
+	curveOrder := curve.Order()
+
+	// z = Scalar(0)
+	z := big.NewInt(0)
+	// for z_i in sig_shares:
+	//     z = z + z_i
+	for _, zi := range signatureShares {
+		z.Add(z, zi)
+		z.Mod(z, curveOrder)
+	}
+
+	// return (group_commitment, z)
+	return groupCommitment, z, nil
+}

--- a/frost/coordinator.go
+++ b/frost/coordinator.go
@@ -12,11 +12,14 @@ type Coordinator struct {
 
 // Aggregate implements Signature Share Aggregation from [FROST], section
 // 5.3. Signature Share Aggregation.
+//
+// Note that the signature produced by the signature share aggregation in
+// [FROST] may not be valid if there are malicious signers present.
 func (c *Coordinator) Aggregate(
 	message []byte,
 	commitments []*NonceCommitment,
 	signatureShares []*big.Int,
-) (*Point, *big.Int, error) {
+) (*Signature, error) {
 	// From [FROST]:
 	//
 	// 5.3.  Signature Share Aggregation
@@ -52,7 +55,7 @@ func (c *Coordinator) Aggregate(
 
 	validationErrors, _ := c.validateGroupCommitmentsBase(commitments)
 	if len(validationErrors) != 0 {
-		return nil, nil, errors.Join(validationErrors...)
+		return nil, errors.Join(validationErrors...)
 	}
 
 	// binding_factor_list = compute_binding_factors(group_public_key, commitment_list, msg)
@@ -74,5 +77,5 @@ func (c *Coordinator) Aggregate(
 	}
 
 	// return (group_commitment, z)
-	return groupCommitment, z, nil
+	return &Signature{groupCommitment, z}, nil
 }

--- a/frost/frost.go
+++ b/frost/frost.go
@@ -1,1 +1,0 @@
-package frost

--- a/frost/participant.go
+++ b/frost/participant.go
@@ -412,11 +412,10 @@ func (p *Participant) computeChallenge(
 	//
 	// def compute_group_commitment(commitment_list, binding_factor_list)
 
-	curve := p.ciphersuite.Curve()
 	// group_comm_enc = G.SerializeElement(group_commitment)
-	groupCommitmentEncoded := curve.SerializePoint(groupCommitment)
+	groupCommitmentEncoded := p.ciphersuite.EncodePoint(groupCommitment)
 	// group_public_key_enc = G.SerializeElement(group_public_key)
-	publicKeyEncoded := curve.SerializePoint(p.publicKey)
+	publicKeyEncoded := p.ciphersuite.EncodePoint(p.publicKey)
 	// challenge_input = group_comm_enc || group_public_key_enc || msg
 	// challenge = H2(challenge_input)
 	// return challenge

--- a/frost/participant.go
+++ b/frost/participant.go
@@ -1,0 +1,323 @@
+package frost
+
+import (
+	"encoding/binary"
+	"math/big"
+)
+
+// Participant implements the base functionality for all [FROST] protocol
+// participants, no matter the participant type: signer, coordinator, or both.
+type Participant struct {
+	ciphersuite Ciphersuite
+
+	publicKey *Point // group_public_key in [FROST]
+}
+
+// NonceCommitment is a message produced in Round One of [FROST].
+type NonceCommitment struct {
+	signerIndex            uint64
+	hidingNonceCommitment  *Point
+	bindingNonceCommitment *Point
+}
+
+// bindingFactors is a helper structure produced by computeBindingFactors function.
+type bindingFactors map[uint64]*big.Int
+
+// computeBindingFactors implements def compute_binding_factors(group_public_key,
+// commitment_list, msg) function from [FROST], as defined in section 4.4. Binding
+// Factors Computation.
+//
+// The function calling computeBindingFactors must ensure a valid number of
+// commitments have been received and call validateGroupCommitment to validate
+// the received commitments.
+func (p *Participant) computeBindingFactors(
+	message []byte,
+	commitments []*NonceCommitment,
+) bindingFactors {
+	// From [FROST]:
+	//
+	// 4.4.  Binding Factors Computation
+	//
+	//   This section describes the subroutine for computing binding factors
+	//   based on the participant commitment list, message to be signed, and
+	//   group public key.
+	//
+	//   Inputs:
+	//     - group_public_key, the public key corresponding to the group signing
+	//       key, an Element.
+	//     - commitment_list = [(i, hiding_nonce_commitment_i,
+	//       binding_nonce_commitment_i), ...], a list of commitments issued by
+	//       each participant, where each element in the list indicates a
+	//       NonZeroScalar identifier i and two commitment Element values
+	//       (hiding_nonce_commitment_i, binding_nonce_commitment_i). This list
+	//       MUST be sorted in ascending order by identifier.
+	//     - msg, the message to be signed.
+	//
+	//   Outputs:
+	//     - binding_factor_list, a list of (NonZeroScalar, Scalar) tuples
+	//       representing the binding factors.
+
+	// group_public_key_enc = G.SerializeElement(group_public_key)
+	curve := p.ciphersuite.Curve()
+	groupPublicKeyEncoded := curve.SerializePoint(p.publicKey)
+
+	// msg_hash = H4(msg)
+	msgHash := p.ciphersuite.H4(message)
+
+	// encoded_commitment_hash =
+	//    H5(encode_group_commitment_list(commitment_list))
+	groupCommitmentEncoded := p.encodeGroupCommitment(commitments)
+	encodedCommitHash := p.ciphersuite.H5(groupCommitmentEncoded)
+
+	// rho_input_prefix = group_public_key_enc || msg_hash || encoded_commitment_hash
+	rhoInputPrefix := concat(groupPublicKeyEncoded, msgHash, encodedCommitHash)
+
+	// binding_factor_list = []
+	bindingFactors := make(map[uint64]*big.Int, len(commitments))
+
+	// for (identifier, hiding_nonce_commitment,
+	//      binding_nonce_commitment) in commitment_list:
+	for _, commitment := range commitments {
+		// rho_input = rho_input_prefix || G.SerializeScalar(identifier)
+		rhoInput := make([]byte, len(rhoInputPrefix)+8)
+		copy(rhoInput, rhoInputPrefix)
+		binary.BigEndian.AppendUint64(rhoInput, commitment.signerIndex)
+		// binding_factor = H1(rho_input)
+		bindingFactor := p.ciphersuite.H1(rhoInput)
+		// binding_factor_list.append((identifier, binding_factor))
+		bindingFactors[commitment.signerIndex] = bindingFactor
+	}
+
+	// return binding_factor_list
+	return bindingFactors
+}
+
+// computeGroupCommitment implements def compute_group_commitment(commitment_list,
+// binding_factor_list) function from [FROST], as defined in section 4.5. Group
+// Commitment Computation.
+//
+// The function calling computeGroupCommitment must ensure a valid number of
+// commitments have been received and call validateGroupCommitment to validate
+// the received commitments.
+func (p *Participant) computeGroupCommitment(
+	commitments []*NonceCommitment,
+	bindingFactors bindingFactors,
+) *Point {
+	// From [FROST]:
+	//
+	// 4.5.  Group Commitment Computation
+	//
+	//   This section describes the subroutine for creating the group
+	//   commitment from a commitment list.
+	//
+	//   Inputs:
+	//     - commitment_list = [(i, hiding_nonce_commitment_i,
+	//       binding_nonce_commitment_i), ...], a list of commitments issued by
+	//       each participant, where each element in the list indicates a
+	//       NonZeroScalar identifier i and two commitment Element values
+	//       (hiding_nonce_commitment_i, binding_nonce_commitment_i). This list
+	//       MUST be sorted in ascending order by identifier.
+	//     - binding_factor_list = [(i, binding_factor), ...],
+	//       a list of (NonZeroScalar, Scalar) tuples representing the binding
+	//       factor Scalar for the given identifier.
+	//
+	//   Outputs:
+	//     - group_commitment, an Element.
+
+	curve := p.ciphersuite.Curve()
+
+	// group_commitment = G.Identity()
+	groupCommitment := curve.Identity()
+
+	// for (identifier, hiding_nonce_commitment,
+	//     binding_nonce_commitment) in commitment_list:
+	for _, commitment := range commitments {
+		// binding_factor = binding_factor_for_participant(
+		//     binding_factor_list, identifier)
+		bindingFactor := bindingFactors[commitment.signerIndex]
+		// binding_nonce = G.ScalarMult(
+		//     binding_nonce_commitment,
+		//     binding_factor)
+		bindingNonce := curve.EcMul(
+			commitment.bindingNonceCommitment,
+			bindingFactor,
+		)
+		// group_commitment = (
+		//     group_commitment +
+		//     hiding_nonce_commitment +
+		//     binding_nonce)
+		groupCommitment = curve.EcAdd(
+			groupCommitment,
+			curve.EcAdd(commitment.hidingNonceCommitment, bindingNonce),
+		)
+	}
+
+	// return group_commitment
+	return groupCommitment
+}
+
+// encodeGroupCommitment implements def encode_group_commitment_list(commitment_list)
+// function from [FROST], as defined in section 4.3. List Operations.
+//
+// The function calling encodeGroupCommitment must ensure a valid number of
+// commitments have been received and call validateGroupCommitment to validate
+// the received commitments.
+func (p *Participant) encodeGroupCommitment(
+	commitments []*NonceCommitment,
+) []byte {
+	// From [FROST]:
+	//
+	// 4.3.  List Operations
+	//
+	//   This section describes helper functions that work on lists of values
+	//   produced during the FROST protocol.  The following function encodes a
+	//   list of participant commitments into a byte string for use in the
+	//   FROST protocol.
+	//
+	//   Inputs:
+	//     - commitment_list = [(i, hiding_nonce_commitment_i,
+	//       binding_nonce_commitment_i), ...], a list of commitments issued by
+	//       each participant, where each element in the list indicates a
+	//       NonZeroScalar identifier i and two commitment Element values
+	//       (hiding_nonce_commitment_i, binding_nonce_commitment_i). This list
+	//       MUST be sorted in ascending order by identifier.
+	//
+	//   Outputs:
+	//     - encoded_group_commitment, the serialized representation of
+	//       commitment_list, a byte string.
+	//
+	//   def encode_group_commitment_list(commitment_list):
+
+	curve := p.ciphersuite.Curve()
+	ecPointLength := curve.SerializedPointLength()
+
+	// preallocate the necessary space to avoid waste:
+	// 8 bytes for signerIndex (uint64)
+	// ecPointLength for hidingNonceCommitment
+	// ecPointLength for bindingNonceCommitment
+	b := make([]byte, 0, (8+2*ecPointLength)*len(commitments))
+
+	// encoded_group_commitment = nil
+	// for (identifier, hiding_nonce_commitment,
+	//      binding_nonce_commitment) in commitment_list:
+	for _, c := range commitments {
+		// encoded_commitment = (
+		//     G.SerializeScalar(identifier) ||
+		//     G.SerializeElement(hiding_nonce_commitment) ||
+		//     G.SerializeElement(binding_nonce_commitment))
+		// encoded_group_commitment = (
+		//     encoded_group_commitment ||
+		//     encoded_commitment)
+		b = binary.BigEndian.AppendUint64(b, c.signerIndex)
+		b = append(b, curve.SerializePoint(c.hidingNonceCommitment)...)
+		b = append(b, curve.SerializePoint(c.bindingNonceCommitment)...)
+	}
+
+	// return encoded_group_commitment
+	return b
+}
+
+// deriveInterpolatingValue implements def derive_interpolating_value(L, x_i)
+// function from [FROST], as defined in section 4.2 Polynomials.
+// L is the list of the indices of the members of the particular group.
+// xi is the index of the participant i.
+//
+// The function calling deriveInterpolatingValue must ensure a valid number of
+// commitments have been received and call validateGroupCommitment to validate
+// the received commitments.
+func (p *Participant) deriveInterpolatingValue(xi uint64, L []uint64) *big.Int {
+	// From [FROST]:
+	//
+	// 4.2.  Polynomials
+	//
+	//   This section defines polynomials over Scalars that are used in the
+	//   main protocol.  A polynomial of maximum degree t is represented as a
+	//   list of t+1 coefficients, where the constant term of the polynomial
+	//   is in the first position and the highest-degree coefficient is in the
+	//   last position.  For example, the polynomial x^2 + 2x + 3 has degree 2
+	//   and is represented as a list of 3 coefficients [3, 2, 1].  A point on
+	//   the polynomial f is a tuple (x, y), where y = f(x).
+	//
+	//   The function derive_interpolating_value derives a value used for
+	//   polynomial interpolation.  It is provided a list of x-coordinates as
+	//   input, each of which cannot equal 0.
+	//
+	//   Inputs:
+	//     - L, the list of x-coordinates, each a NonZeroScalar.
+	//     - x_i, an x-coordinate contained in L, a NonZeroScalar.
+	//
+	//   Outputs:
+	//     - value, a Scalar.
+	//
+	//   Errors:
+	//     - "invalid parameters", if 1) x_i is not in L, or if 2) any
+	//       x-coordinate is represented more than once in L.
+	//
+	//   def derive_interpolating_value(L, x_i):
+
+	// Note that the validation is handled in validateGroupCommitment function.
+
+	order := p.ciphersuite.Curve().Order()
+	// numerator = Scalar(1)
+	num := big.NewInt(1)
+	// denominator = Scalar(1)
+	den := big.NewInt(1)
+	// for x_j in L:
+	for _, xj := range L {
+		if xj == xi {
+			// if x_j == x_i: continue
+			continue
+		}
+		// numerator *= x_j
+		num.Mul(num, big.NewInt(int64(xj)))
+		num.Mod(num, order)
+		// denominator *= x_j - x_i
+		den.Mul(den, big.NewInt(int64(xj)-int64(xi)))
+		den.Mod(den, order)
+	}
+
+	// value = numerator / denominator
+	denInv := new(big.Int).ModInverse(den, order)
+	res := new(big.Int).Mul(num, denInv)
+	res = res.Mod(res, order)
+
+	// return value
+	return res
+}
+
+// computeChallenge implements def compute_group_commitment(commitment_list,
+// binding_factor_list) from [FROST] as defined in section 4.6. Signature
+// Challenge Computation.
+func (p *Participant) computeChallenge(
+	message []byte,
+	groupCommitment *Point,
+) *big.Int {
+
+	// From [FROST]:
+	//
+	// 4.6.  Signature Challenge Computation
+	//
+	//   This section describes the subroutine for creating the per-message
+	//   challenge.
+	//
+	//   Inputs:
+	//     - group_commitment, the group commitment, an Element.
+	//     - group_public_key, the public key corresponding to the group signing
+	//       key, an Element.
+	//     - msg, the message to be signed, a byte string.
+	//
+	//   Outputs:
+	//     - challenge, a Scalar.
+	//
+	// def compute_group_commitment(commitment_list, binding_factor_list)
+
+	curve := p.ciphersuite.Curve()
+	// group_comm_enc = G.SerializeElement(group_commitment)
+	groupCommitmentEncoded := curve.SerializePoint(groupCommitment)
+	// group_public_key_enc = G.SerializeElement(group_public_key)
+	publicKeyEncoded := curve.SerializePoint(p.publicKey)
+	// challenge_input = group_comm_enc || group_public_key_enc || msg
+	// challenge = H2(challenge_input)
+	// return challenge
+	return p.ciphersuite.H2(groupCommitmentEncoded, publicKeyEncoded, message)
+}

--- a/frost/participant_test.go
+++ b/frost/participant_test.go
@@ -1,0 +1,293 @@
+package frost
+
+import (
+	"encoding/hex"
+	"fmt"
+	"math/big"
+	"testing"
+
+	"threshold.network/roast/internal/testutils"
+)
+
+func TestValidateGroupCommitmentsBase(t *testing.T) {
+	// happy path
+	signers := createSigners(t)
+	_, commitments := executeRound1(t, signers)
+
+	participant := &Participant{
+		ciphersuite: signers[0].ciphersuite,
+	}
+
+	validationErrors, participants := participant.validateGroupCommitmentsBase(commitments)
+	testutils.AssertIntsEqual(t, "number of validation errors", 0, len(validationErrors))
+	testutils.AssertIntsEqual(t, "number of participants", groupSize, len(participants))
+
+	for i, p := range participants {
+		expected := uint64(i + 1)
+		if p != expected {
+			testutils.AssertUintsEqual(t, "participant index", expected, p)
+		}
+	}
+}
+
+func TestValidateGroupCommitmentsBase_Errors(t *testing.T) {
+	tests := map[string]struct {
+		modifyCommitments func([]*NonceCommitment) []*NonceCommitment
+		expectedErrors    []string
+	}{
+		"nil in the array": {
+			modifyCommitments: func(commitments []*NonceCommitment) []*NonceCommitment {
+				commitments[30] = nil
+				return commitments
+			},
+			expectedErrors: []string{
+				"commitment at position [30] is nil",
+			},
+		},
+		"duplicate commitment": {
+			modifyCommitments: func(commitments []*NonceCommitment) []*NonceCommitment {
+				// duplicate commitment from signer 5 at positions 4 and 5
+				commitments[5] = commitments[4]
+				return commitments
+			},
+			expectedErrors: []string{
+				"commitments not sorted in ascending order: commitments[4].signerIndex=5, commitments[5].signerIndex=5",
+			},
+		},
+		"commitments in invalid order": {
+			modifyCommitments: func(commitments []*NonceCommitment) []*NonceCommitment {
+				// at the position where we'd expect a commitment from signer 32 we have
+				// a commitment from signer 51
+				tmp := commitments[31]
+				commitments[31] = commitments[50]
+				// at the position where we'd expect a commitment from signer 51 we have
+				// a commitment from signer 32
+				commitments[50] = tmp
+				return commitments
+			},
+			expectedErrors: []string{
+				"commitments not sorted in ascending order: commitments[31].signerIndex=51, commitments[32].signerIndex=33",
+				"commitments not sorted in ascending order: commitments[49].signerIndex=50, commitments[50].signerIndex=32",
+			},
+		},
+		"invalid binding nonce commitment": {
+			modifyCommitments: func(commitments []*NonceCommitment) []*NonceCommitment {
+				// binding nonce commitment for signer 81 is an invalid curve point
+				commitments[80].bindingNonceCommitment = &Point{big.NewInt(100), big.NewInt(200)}
+				return commitments
+			},
+			expectedErrors: []string{
+				"binding nonce commitment from signer [81] is not a valid non-identity point on the curve: [Point[X=0x64, Y=0xc8]]",
+			},
+		},
+		"invalid hiding nonce commitment": {
+			modifyCommitments: func(commitments []*NonceCommitment) []*NonceCommitment {
+				// hiding nonce commitment for signer 100 is an invalid curve point
+				commitments[99].hidingNonceCommitment = &Point{big.NewInt(300), big.NewInt(400)}
+				return commitments
+			},
+			expectedErrors: []string{
+				"hiding nonce commitment from signer [100] is not a valid non-identity point on the curve: [Point[X=0x12c, Y=0x190]]",
+			},
+		},
+		"multiple problems": {
+			modifyCommitments: func(commitments []*NonceCommitment) []*NonceCommitment {
+				// duplicate commitment from signer 5 at positions 4 and 5
+				commitments[5] = commitments[4]
+				// at the position where we'd expect a commitment from signer 32 we have
+				// a commitment from signer 51
+				tmp := commitments[31]
+				commitments[31] = commitments[50]
+				// at the position where we'd expect a commitment from signer 51 we have
+				// a commitment from signer 32
+				commitments[50] = tmp
+				// binding nonce commitment for signer 81 is an invalid curve point
+				commitments[80].bindingNonceCommitment = &Point{big.NewInt(100), big.NewInt(200)}
+				// hiding nonce commitment for signer 100 is an invalid curve point
+				commitments[99].hidingNonceCommitment = &Point{big.NewInt(300), big.NewInt(400)}
+				// finally, we'll set the nil commitment at position 97 where we would
+				// expect a commitment from signer 98
+				commitments[97] = nil
+				return commitments
+			},
+			expectedErrors: []string{
+				"commitments not sorted in ascending order: commitments[4].signerIndex=5, commitments[5].signerIndex=5",
+				"commitments not sorted in ascending order: commitments[31].signerIndex=51, commitments[32].signerIndex=33",
+				"commitments not sorted in ascending order: commitments[49].signerIndex=50, commitments[50].signerIndex=32",
+				"binding nonce commitment from signer [81] is not a valid non-identity point on the curve: [Point[X=0x64, Y=0xc8]]",
+				"commitment at position [97] is nil",
+				"hiding nonce commitment from signer [100] is not a valid non-identity point on the curve: [Point[X=0x12c, Y=0x190]]",
+			},
+		},
+	}
+
+	for testName, test := range tests {
+		t.Run(testName, func(t *testing.T) {
+			signers := createSigners(t)
+			_, commitments := executeRound1(t, signers)
+
+			participant := &Participant{
+				ciphersuite: signers[0].ciphersuite,
+			}
+
+			modified := test.modifyCommitments(commitments)
+			validationErrors, participants := participant.validateGroupCommitmentsBase(modified)
+
+			if participants != nil {
+				t.Fatalf("expected nil participants list, has [%v]", participants)
+			}
+
+			testutils.AssertIntsEqual(
+				t,
+				"number of validation errors",
+				len(test.expectedErrors),
+				len(validationErrors),
+			)
+			if len(test.expectedErrors) != len(validationErrors) {
+				// Using Fatalf directly to not execute the rest of assertions
+				t.Fatalf(
+					"unexpected number of validation errors\nexpected: %v\nactual:   %v\n",
+					len(test.expectedErrors),
+					len(validationErrors),
+				)
+			}
+
+			for i, expectedError := range test.expectedErrors {
+				testutils.AssertStringsEqual(
+					t,
+					fmt.Sprintf("validation error #%d", i),
+					expectedError,
+					validationErrors[i].Error(),
+				)
+			}
+		})
+	}
+}
+
+func TestEncodeGroupCommitments(t *testing.T) {
+	hidingNonceCommitments := [][]string{
+		{"d01115d548e7561b15c38f004d734633687cf4419620095bc5b0f47070afe85a", "a9f34ffdc815e0d7a8b64537e17bd81579238c5dd9a86d526b051b13f4062327"}, // G*12
+		{"f28773c2d975288bc7d1d205c3748651b075fbc6610e58cddeeddf8f19405aa8", "ab0902e8d880a89758212eb65cdaf473a1a06da521fa91f29b5cb52db03ed81"},  // G*13
+		{"499fdf9e895e719cfd64e67f07d38e3226aa7b63678949e6e49b241a60e823e4", "cac2f6c4b54e855190f044e4a7b3d464464279c27a3f95bcc65f40d403a13f5b"}, // G*14
+	}
+
+	bindingNonceCommitments := [][]string{
+		{"136933174bc388a74ebd6746e13afe0eef5d66580c8e23d33464c342dc0080", "27015dc47dbfe781689f232541c0410560ac69c82044e8e5906e54680127ff92"},   // G*246
+		{"9e2158f0d7c0d5f26c3791efefa79597654e7a2b2464f52b1ee6c1347769ef57", "712fcdd1b9053f09003a3481fa7762e9ffd7c8ef35a38509e2fbf2629008373"},  // G*247
+		{"22213b78f3dcfbdfeb76cc1731c1ba318b2b0c32f081e206f50618fa7eaf5aa3", "dd81b694ec3a60bad2a203d8eedc863fe476add5cf7391740d86e5c8718a3051"}, //G*248
+	}
+
+	// note all data types occupy the same byte length and are left-padded, if necessary
+	expectedEncoded := "" +
+		"0000000000000001" + // signer[0] index
+		"04d01115d548e7561b15c38f004d734633687cf4419620095bc5b0f47070afe85aa9f34ffdc815e0d7a8b64537e17bd81579238c5dd9a86d526b051b13f4062327" + // hiding nonce [0]
+		"0400136933174bc388a74ebd6746e13afe0eef5d66580c8e23d33464c342dc008027015dc47dbfe781689f232541c0410560ac69c82044e8e5906e54680127ff92" + // binding nonce [0]
+		"0000000000000002" + // signer [1] index
+		"04f28773c2d975288bc7d1d205c3748651b075fbc6610e58cddeeddf8f19405aa80ab0902e8d880a89758212eb65cdaf473a1a06da521fa91f29b5cb52db03ed81" + // hiding nonce [1]
+		"049e2158f0d7c0d5f26c3791efefa79597654e7a2b2464f52b1ee6c1347769ef570712fcdd1b9053f09003a3481fa7762e9ffd7c8ef35a38509e2fbf2629008373" + // binding nonce [1]
+		"0000000000000003" + // signer [2] index
+		"04499fdf9e895e719cfd64e67f07d38e3226aa7b63678949e6e49b241a60e823e4cac2f6c4b54e855190f044e4a7b3d464464279c27a3f95bcc65f40d403a13f5b" + // hiding nonce [2]
+		"0422213b78f3dcfbdfeb76cc1731c1ba318b2b0c32f081e206f50618fa7eaf5aa3dd81b694ec3a60bad2a203d8eedc863fe476add5cf7391740d86e5c8718a3051" // binding nonce [2]
+
+	var commitments []*NonceCommitment
+	for i, c := range hidingNonceCommitments {
+		hnx, _ := new(big.Int).SetString(c[0], 16)
+		hny, _ := new(big.Int).SetString(c[1], 16)
+
+		bnx, _ := new(big.Int).SetString(bindingNonceCommitments[i][0], 16)
+		bny, _ := new(big.Int).SetString(bindingNonceCommitments[i][1], 16)
+
+		commitments = append(commitments, &NonceCommitment{
+			signerIndex:            uint64(i + 1),
+			hidingNonceCommitment:  &Point{hnx, hny},
+			bindingNonceCommitment: &Point{bnx, bny},
+		})
+	}
+
+	participant := &Participant{
+		ciphersuite: NewBip340Ciphersuite(),
+	}
+	encoded := participant.encodeGroupCommitment(commitments)
+
+	testutils.AssertStringsEqual(
+		t,
+		"encoded data",
+		expectedEncoded,
+		hex.EncodeToString(encoded),
+	)
+}
+
+func TestDeriveInterpolatingValue(t *testing.T) {
+	var tests = map[string]struct {
+		xi       uint64
+		L        []uint64
+		expected string
+	}{
+		// Lagrange coefficient l_0 is:
+		//
+		//       (x-4)(x-5)
+		// l_0 = ----------
+		//       (1-4)(1-5)
+		//
+		// Since x is always 0 for this function, l_0 = 20/12 (mod Q).
+		//
+		// Then we calculate ((12^-1 mod Q) * 20) mod Q
+		// where Q is the order of secp256k1.
+		//
+		"xi = 1, L = {1, 4, 5}": {
+			xi:       1,
+			L:        []uint64{1, 4, 5},
+			expected: "38597363079105398474523661669562635950945854759691634794201721047172720498114",
+		},
+		// Lagrange coefficient l_1 is:
+		//
+		//       (x-1)(x-5)
+		// l_1 = ----------
+		//       (4-1)(4-5)
+		//
+		// Since x is always 0 for this function, l_0 = 5/-3 (mod Q).
+		// Given the negative denominator and mod Q, the number will be
+		// l_0 = 5/(Q-3).
+		//
+		// Then we calculate (((Q-3)^-1 mod Q) * 5) mod Q
+		// where Q is the order of secp256k1.
+		//
+		"xi = 4, L = {1, 4, 5}": {
+			xi:       4,
+			L:        []uint64{1, 4, 5},
+			expected: "77194726158210796949047323339125271901891709519383269588403442094345440996223",
+		},
+		// Lagrange coefficient l_2 is:
+		//
+		//       (x-1)(x-4)
+		// l_1 = ----------
+		//       (5-1)(5-4)
+		//
+		// Since x is always 0 for this function, l_0 = 4/4 (mod Q).
+		//
+		// Then we calculate ((1^-1 mod Q) * 1) mod Q
+		// where Q is the order of secp256k1.
+		//
+		"xi = 5, L = {1, 4, 5}": {
+			xi:       5,
+			L:        []uint64{1, 4, 5},
+			expected: "1",
+		},
+	}
+
+	participant := &Participant{
+		ciphersuite: NewBip340Ciphersuite(),
+	}
+
+	for testName, test := range tests {
+		t.Run(testName, func(t *testing.T) {
+			result := participant.deriveInterpolatingValue(test.xi, test.L)
+			testutils.AssertStringsEqual(
+				t,
+				"interpolating value",
+				test.expected,
+				result.Text(10),
+			)
+		})
+	}
+}

--- a/frost/signer.go
+++ b/frost/signer.go
@@ -2,7 +2,6 @@ package frost
 
 import (
 	"crypto/rand"
-	"encoding/binary"
 	"errors"
 	"fmt"
 	"math/big"
@@ -10,11 +9,10 @@ import (
 
 // Signer represents a single participant of the [FROST] signing protocol.
 type Signer struct {
-	ciphersuite Ciphersuite
+	Participant
 
 	signerIndex    uint64   // i in [FROST]
 	secretKeyShare *big.Int // sk_i in [FROST]
-	publicKey      *Point   // group_public_key in [FROST]
 }
 
 // Nonce is a message produced in Round One of [FROST].
@@ -23,16 +21,22 @@ type Nonce struct {
 	bindingNonce *big.Int
 }
 
-// NonceCommitment is a message produced in Round One of [FROST].
-type NonceCommitment struct {
-	signerIndex            uint64
-	hidingNonceCommitment  *Point
-	bindingNonceCommitment *Point
+// NewSigner creates a new [FROST] Signer instance.
+func NewSigner(
+	ciphersuite Ciphersuite,
+	signerIndex uint64,
+	publicKey *Point,
+	secretKeyShare *big.Int,
+) *Signer {
+	return &Signer{
+		Participant: Participant{
+			ciphersuite: ciphersuite,
+			publicKey:   publicKey,
+		},
+		signerIndex:    signerIndex,
+		secretKeyShare: secretKeyShare,
+	}
 }
-
-// bindingFactors is a helper structure produced by computeBindingFactors
-// function in the Round Two of [FROST] and used across round two functions.
-type bindingFactors map[uint64]*big.Int
 
 // Round1 implements the Round One - Commitment phase from [FROST], section
 // 5.1.  Round One - Commitment.
@@ -250,300 +254,4 @@ func (s *Signer) validateGroupCommitments(
 	}
 
 	return errors, nil
-}
-
-// computeBindingFactors implements def compute_binding_factors(group_public_key,
-// commitment_list, msg) function from [FROST], as defined in section 4.4. Binding
-// Factors Computation.
-//
-// The function calling computeBindingFactors must ensure a valid number of
-// commitments have been received and call validateGroupCommitment to validate
-// the received commitments.
-func (s *Signer) computeBindingFactors(
-	message []byte,
-	commitments []*NonceCommitment,
-) bindingFactors {
-	// From [FROST]:
-	//
-	// 4.4.  Binding Factors Computation
-	//
-	//   This section describes the subroutine for computing binding factors
-	//   based on the participant commitment list, message to be signed, and
-	//   group public key.
-	//
-	//   Inputs:
-	//     - group_public_key, the public key corresponding to the group signing
-	//       key, an Element.
-	//     - commitment_list = [(i, hiding_nonce_commitment_i,
-	//       binding_nonce_commitment_i), ...], a list of commitments issued by
-	//       each participant, where each element in the list indicates a
-	//       NonZeroScalar identifier i and two commitment Element values
-	//       (hiding_nonce_commitment_i, binding_nonce_commitment_i). This list
-	//       MUST be sorted in ascending order by identifier.
-	//     - msg, the message to be signed.
-	//
-	//   Outputs:
-	//     - binding_factor_list, a list of (NonZeroScalar, Scalar) tuples
-	//       representing the binding factors.
-
-	// group_public_key_enc = G.SerializeElement(group_public_key)
-	curve := s.ciphersuite.Curve()
-	groupPublicKeyEncoded := curve.SerializePoint(s.publicKey)
-
-	// msg_hash = H4(msg)
-	msgHash := s.ciphersuite.H4(message)
-
-	// encoded_commitment_hash =
-	//    H5(encode_group_commitment_list(commitment_list))
-	encodedCommitHash := s.ciphersuite.H5(s.encodeGroupCommitment(commitments))
-
-	// rho_input_prefix = group_public_key_enc || msg_hash || encoded_commitment_hash
-	rhoInputPrefix := concat(groupPublicKeyEncoded, msgHash, encodedCommitHash)
-
-	// binding_factor_list = []
-	bindingFactors := make(map[uint64]*big.Int, len(commitments))
-
-	// for (identifier, hiding_nonce_commitment,
-	//      binding_nonce_commitment) in commitment_list:
-	for _, commitment := range commitments {
-		// rho_input = rho_input_prefix || G.SerializeScalar(identifier)
-		rhoInput := make([]byte, len(rhoInputPrefix)+8)
-		copy(rhoInput, rhoInputPrefix)
-		binary.BigEndian.AppendUint64(rhoInput, commitment.signerIndex)
-		// binding_factor = H1(rho_input)
-		bindingFactor := s.ciphersuite.H1(rhoInput)
-		// binding_factor_list.append((identifier, binding_factor))
-		bindingFactors[commitment.signerIndex] = bindingFactor
-	}
-
-	// return binding_factor_list
-	return bindingFactors
-}
-
-// computeGroupCommitment implements def compute_group_commitment(commitment_list,
-// binding_factor_list) function from [FROST], as defined in section 4.5. Group
-// Commitment Computation.
-//
-// The function calling computeGroupCommitment must ensure a valid number of
-// commitments have been received and call validateGroupCommitment to validate
-// the received commitments.
-func (s *Signer) computeGroupCommitment(
-	commitments []*NonceCommitment,
-	bindingFactors bindingFactors,
-) *Point {
-	// From [FROST]:
-	//
-	// 4.5.  Group Commitment Computation
-	//
-	//   This section describes the subroutine for creating the group
-	//   commitment from a commitment list.
-	//
-	//   Inputs:
-	//     - commitment_list = [(i, hiding_nonce_commitment_i,
-	//       binding_nonce_commitment_i), ...], a list of commitments issued by
-	//       each participant, where each element in the list indicates a
-	//       NonZeroScalar identifier i and two commitment Element values
-	//       (hiding_nonce_commitment_i, binding_nonce_commitment_i). This list
-	//       MUST be sorted in ascending order by identifier.
-	//     - binding_factor_list = [(i, binding_factor), ...],
-	//       a list of (NonZeroScalar, Scalar) tuples representing the binding
-	//       factor Scalar for the given identifier.
-	//
-	//   Outputs:
-	//     - group_commitment, an Element.
-
-	curve := s.ciphersuite.Curve()
-
-	// group_commitment = G.Identity()
-	groupCommitment := curve.Identity()
-
-	// for (identifier, hiding_nonce_commitment,
-	//     binding_nonce_commitment) in commitment_list:
-	for _, commitment := range commitments {
-		// binding_factor = binding_factor_for_participant(
-		//     binding_factor_list, identifier)
-		bindingFactor := bindingFactors[commitment.signerIndex]
-		// binding_nonce = G.ScalarMult(
-		//     binding_nonce_commitment,
-		//     binding_factor)
-		bindingNonce := curve.EcMul(
-			commitment.bindingNonceCommitment,
-			bindingFactor,
-		)
-		// group_commitment = (
-		//     group_commitment +
-		//     hiding_nonce_commitment +
-		//     binding_nonce)
-		groupCommitment = curve.EcAdd(
-			groupCommitment,
-			curve.EcAdd(commitment.hidingNonceCommitment, bindingNonce),
-		)
-	}
-
-	// return group_commitment
-	return groupCommitment
-}
-
-// encodeGroupCommitment implements def encode_group_commitment_list(commitment_list)
-// function from [FROST], as defined in section 4.3. List Operations.
-//
-// The function calling encodeGroupCommitment must ensure a valid number of
-// commitments have been received and call validateGroupCommitment to validate
-// the received commitments.
-func (s *Signer) encodeGroupCommitment(commitments []*NonceCommitment) []byte {
-	// From [FROST]:
-	//
-	// 4.3.  List Operations
-	//
-	//   This section describes helper functions that work on lists of values
-	//   produced during the FROST protocol.  The following function encodes a
-	//   list of participant commitments into a byte string for use in the
-	//   FROST protocol.
-	//
-	//   Inputs:
-	//     - commitment_list = [(i, hiding_nonce_commitment_i,
-	//       binding_nonce_commitment_i), ...], a list of commitments issued by
-	//       each participant, where each element in the list indicates a
-	//       NonZeroScalar identifier i and two commitment Element values
-	//       (hiding_nonce_commitment_i, binding_nonce_commitment_i). This list
-	//       MUST be sorted in ascending order by identifier.
-	//
-	//   Outputs:
-	//     - encoded_group_commitment, the serialized representation of
-	//       commitment_list, a byte string.
-	//
-	//   def encode_group_commitment_list(commitment_list):
-
-	curve := s.ciphersuite.Curve()
-	ecPointLength := curve.SerializedPointLength()
-
-	// preallocate the necessary space to avoid waste:
-	// 8 bytes for signerIndex (uint64)
-	// ecPointLength for hidingNonceCommitment
-	// ecPointLength for bindingNonceCommitment
-	b := make([]byte, 0, (8+2*ecPointLength)*len(commitments))
-
-	// encoded_group_commitment = nil
-	// for (identifier, hiding_nonce_commitment,
-	//      binding_nonce_commitment) in commitment_list:
-	for _, c := range commitments {
-		// encoded_commitment = (
-		//     G.SerializeScalar(identifier) ||
-		//     G.SerializeElement(hiding_nonce_commitment) ||
-		//     G.SerializeElement(binding_nonce_commitment))
-		// encoded_group_commitment = (
-		//     encoded_group_commitment ||
-		//     encoded_commitment)
-		b = binary.BigEndian.AppendUint64(b, c.signerIndex)
-		b = append(b, curve.SerializePoint(c.hidingNonceCommitment)...)
-		b = append(b, curve.SerializePoint(c.bindingNonceCommitment)...)
-	}
-
-	// return encoded_group_commitment
-	return b
-}
-
-// deriveInterpolatingValue implements def derive_interpolating_value(L, x_i)
-// function from [FROST], as defined in section 4.2 Polynomials.
-// L is the list of the indices of the members of the particular group.
-// xi is the index of the participant i.
-//
-// The function calling deriveInterpolatingValue must ensure a valid number of
-// commitments have been received and call validateGroupCommitment to validate
-// the received commitments.
-func (s *Signer) deriveInterpolatingValue(xi uint64, L []uint64) *big.Int {
-	// From [FROST]:
-	//
-	// 4.2.  Polynomials
-	//
-	//   This section defines polynomials over Scalars that are used in the
-	//   main protocol.  A polynomial of maximum degree t is represented as a
-	//   list of t+1 coefficients, where the constant term of the polynomial
-	//   is in the first position and the highest-degree coefficient is in the
-	//   last position.  For example, the polynomial x^2 + 2x + 3 has degree 2
-	//   and is represented as a list of 3 coefficients [3, 2, 1].  A point on
-	//   the polynomial f is a tuple (x, y), where y = f(x).
-	//
-	//   The function derive_interpolating_value derives a value used for
-	//   polynomial interpolation.  It is provided a list of x-coordinates as
-	//   input, each of which cannot equal 0.
-	//
-	//   Inputs:
-	//     - L, the list of x-coordinates, each a NonZeroScalar.
-	//     - x_i, an x-coordinate contained in L, a NonZeroScalar.
-	//
-	//   Outputs:
-	//     - value, a Scalar.
-	//
-	//   Errors:
-	//     - "invalid parameters", if 1) x_i is not in L, or if 2) any
-	//       x-coordinate is represented more than once in L.
-	//
-	//   def derive_interpolating_value(L, x_i):
-
-	// Note that the validation is handled in validateGroupCommitment function.
-
-	order := s.ciphersuite.Curve().Order()
-	// numerator = Scalar(1)
-	num := big.NewInt(1)
-	// denominator = Scalar(1)
-	den := big.NewInt(1)
-	// for x_j in L:
-	for _, xj := range L {
-		if xj == xi {
-			// if x_j == x_i: continue
-			continue
-		}
-		// numerator *= x_j
-		num.Mul(num, big.NewInt(int64(xj)))
-		num.Mod(num, order)
-		// denominator *= x_j - x_i
-		den.Mul(den, big.NewInt(int64(xj)-int64(xi)))
-		den.Mod(den, order)
-	}
-
-	// value = numerator / denominator
-	denInv := new(big.Int).ModInverse(den, order)
-	res := new(big.Int).Mul(num, denInv)
-	res = res.Mod(res, order)
-
-	// return value
-	return res
-}
-
-// computeChallenge implements def compute_group_commitment(commitment_list,
-// binding_factor_list) from [FROST] as defined in section 4.6. Signature
-// Challenge Computation.
-func (s *Signer) computeChallenge(
-	message []byte,
-	groupCommitment *Point,
-) *big.Int {
-
-	// From [FROST]:
-	//
-	// 4.6.  Signature Challenge Computation
-	//
-	//   This section describes the subroutine for creating the per-message
-	//   challenge.
-	//
-	//   Inputs:
-	//     - group_commitment, the group commitment, an Element.
-	//     - group_public_key, the public key corresponding to the group signing
-	//       key, an Element.
-	//     - msg, the message to be signed, a byte string.
-	//
-	//   Outputs:
-	//     - challenge, a Scalar.
-	//
-	// def compute_group_commitment(commitment_list, binding_factor_list)
-
-	curve := s.ciphersuite.Curve()
-	// group_comm_enc = G.SerializeElement(group_commitment)
-	groupCommitmentEncoded := curve.SerializePoint(groupCommitment)
-	// group_public_key_enc = G.SerializeElement(group_public_key)
-	publicKeyEncoded := curve.SerializePoint(s.publicKey)
-	// challenge_input = group_comm_enc || group_public_key_enc || msg
-	// challenge = H2(challenge_input)
-	// return challenge
-	return s.ciphersuite.H2(groupCommitmentEncoded, publicKeyEncoded, message)
 }

--- a/frost/signer.go
+++ b/frost/signer.go
@@ -39,11 +39,11 @@ func NewSigner(
 }
 
 // Round1 implements the Round One - Commitment phase from [FROST], section
-// 5.1.  Round One - Commitment.
+// 5.1. Round One - Commitment.
 func (s *Signer) Round1() (*Nonce, *NonceCommitment, error) {
 	//	From [FROST]:
 	//
-	//	5.1.  Round One - Commitment
+	//	5.1. Round One - Commitment
 	//
 	//	  Round one involves each participant generating nonces and their
 	//	  corresponding public commitments.  A nonce is a pair of Scalar
@@ -160,7 +160,7 @@ func (s *Signer) validateGroupCommitments(
 ) ([]error, []uint64) {
 	// Validations required, as specified in [FROST]:
 	//
-	// 3.1 Prime-Order Group
+	// 3.1. Prime-Order Group
 	//
 	//   (...)
 	//

--- a/frost/signer.go
+++ b/frost/signer.go
@@ -101,7 +101,7 @@ func (s *Signer) Round2(
 	nonce *Nonce,
 	commitments []*NonceCommitment,
 ) (*big.Int, error) {
-	// TODO: validate number of commitments?
+	// TODO: validate the number of commitments
 
 	// participant_list = participants_from_commitment_list(commitment_list)
 	validationErrors, participants := s.validateGroupCommitments(commitments)
@@ -136,9 +136,8 @@ func (s *Signer) Round2(
 	return sigShare, nil
 }
 
-// validateGroupCommitments is a helper function used internally by
-// encodeGroupCommitment to validate the group commitments. Four validations
-// are done:
+// validateGroupCommitments is a helper function used internally in RoundTwo
+// to validate the group commitments. Four validations are done:
 // - None of the commitments is a point not lying on the curve.
 // - The list of commitments is sorted in ascending order by signer identifier.
 // - This signer's commitment is included in the commitments.
@@ -161,7 +160,15 @@ func (s *Signer) validateGroupCommitments(
 	//   buf of fixed length Ne.  This function raises an error if A is the
 	//   identity element of the group.
 	//
-	// 4.3.  List Operations
+	// 4.2. Polynomials
+	//
+	//   (...)
+	//
+	//   Errors:
+	//    - "invalid parameters", if 1) x_i is not in L, or if 2) any
+	//      x-coordinate is represented more than once in L.
+	//
+	// 4.3. List Operations
 	//
 	//   (...)
 	//

--- a/frost/signer_test.go
+++ b/frost/signer_test.go
@@ -322,12 +322,8 @@ func createSigners(t *testing.T) []*Signer {
 	secretKeyShare := new(big.Int).SetBytes(buf)
 
 	for i := 1; i <= groupSize; i++ {
-		signer := &Signer{
-			ciphersuite:    ciphersuite,
-			signerIndex:    uint64(i),
-			secretKeyShare: secretKeyShare,
-		}
-
+		// TODO: pass real public key instead of nil
+		signer := NewSigner(ciphersuite, uint64(i), nil, secretKeyShare)
 		signers = append(signers, signer)
 	}
 

--- a/frost/signer_test.go
+++ b/frost/signer_test.go
@@ -2,7 +2,6 @@ package frost
 
 import (
 	"crypto/rand"
-	"encoding/hex"
 	"fmt"
 	"math/big"
 	"slices"
@@ -75,52 +74,9 @@ func TestValidateGroupCommitments_Errors(t *testing.T) {
 				"current signer's commitment not found on the list",
 			},
 		},
-		"duplicate commitment": {
-			modifyCommitments: func(commitments []*NonceCommitment) []*NonceCommitment {
-				// duplicate commitment from signer 5 at positions 4 and 5
-				commitments[5] = commitments[4]
-				return commitments
-			},
-			expectedErrors: []string{
-				"commitments not sorted in ascending order: commitments[4].signerIndex=5, commitments[5].signerIndex=5",
-			},
-		},
-		"commitments in invalid order": {
-			modifyCommitments: func(commitments []*NonceCommitment) []*NonceCommitment {
-				// at the position where we'd expect a commitment from signer 32 we have
-				// a commitment from signer 51
-				tmp := commitments[31]
-				commitments[31] = commitments[50]
-				// at the position where we'd expect a commitment from signer 51 we have
-				// a commitment from signer 32
-				commitments[50] = tmp
-				return commitments
-			},
-			expectedErrors: []string{
-				"commitments not sorted in ascending order: commitments[31].signerIndex=51, commitments[32].signerIndex=33",
-				"commitments not sorted in ascending order: commitments[49].signerIndex=50, commitments[50].signerIndex=32",
-			},
-		},
-		"invalid binding nonce commitment": {
-			modifyCommitments: func(commitments []*NonceCommitment) []*NonceCommitment {
-				// binding nonce commitment for signer 81 is an invalid curve point
-				commitments[80].bindingNonceCommitment = &Point{big.NewInt(100), big.NewInt(200)}
-				return commitments
-			},
-			expectedErrors: []string{
-				"binding nonce commitment from signer [81] is not a valid non-identity point on the curve: [Point[X=0x64, Y=0xc8]]",
-			},
-		},
-		"invalid hiding nonce commitment": {
-			modifyCommitments: func(commitments []*NonceCommitment) []*NonceCommitment {
-				// hiding nonce commitment for signer 100 is an invalid curve point
-				commitments[99].hidingNonceCommitment = &Point{big.NewInt(300), big.NewInt(400)}
-				return commitments
-			},
-			expectedErrors: []string{
-				"hiding nonce commitment from signer [100] is not a valid non-identity point on the curve: [Point[X=0x12c, Y=0x190]]",
-			},
-		},
+		// We don't want to repeat all validateGroupCommitmentsBase errors but we want
+		// to ensure this function is called and all sort of errors are detected.
+		// Better be safe than sorry.
 		"multiple problems": {
 			modifyCommitments: func(commitments []*NonceCommitment) []*NonceCommitment {
 				// duplicate commitment from signer 5 at positions 4 and 5
@@ -188,129 +144,6 @@ func TestValidateGroupCommitments_Errors(t *testing.T) {
 					validationErrors[i].Error(),
 				)
 			}
-		})
-	}
-}
-
-func TestEncodeGroupCommitments(t *testing.T) {
-	hidingNonceCommitments := [][]string{
-		{"d01115d548e7561b15c38f004d734633687cf4419620095bc5b0f47070afe85a", "a9f34ffdc815e0d7a8b64537e17bd81579238c5dd9a86d526b051b13f4062327"}, // G*12
-		{"f28773c2d975288bc7d1d205c3748651b075fbc6610e58cddeeddf8f19405aa8", "ab0902e8d880a89758212eb65cdaf473a1a06da521fa91f29b5cb52db03ed81"},  // G*13
-		{"499fdf9e895e719cfd64e67f07d38e3226aa7b63678949e6e49b241a60e823e4", "cac2f6c4b54e855190f044e4a7b3d464464279c27a3f95bcc65f40d403a13f5b"}, // G*14
-	}
-
-	bindingNonceCommitments := [][]string{
-		{"136933174bc388a74ebd6746e13afe0eef5d66580c8e23d33464c342dc0080", "27015dc47dbfe781689f232541c0410560ac69c82044e8e5906e54680127ff92"},   // G*246
-		{"9e2158f0d7c0d5f26c3791efefa79597654e7a2b2464f52b1ee6c1347769ef57", "712fcdd1b9053f09003a3481fa7762e9ffd7c8ef35a38509e2fbf2629008373"},  // G*247
-		{"22213b78f3dcfbdfeb76cc1731c1ba318b2b0c32f081e206f50618fa7eaf5aa3", "dd81b694ec3a60bad2a203d8eedc863fe476add5cf7391740d86e5c8718a3051"}, //G*248
-	}
-
-	// note all data types occupy the same byte length and are left-padded, if necessary
-	expectedEncoded := "" +
-		"0000000000000001" + // signer[0] index
-		"04d01115d548e7561b15c38f004d734633687cf4419620095bc5b0f47070afe85aa9f34ffdc815e0d7a8b64537e17bd81579238c5dd9a86d526b051b13f4062327" + // hiding nonce [0]
-		"0400136933174bc388a74ebd6746e13afe0eef5d66580c8e23d33464c342dc008027015dc47dbfe781689f232541c0410560ac69c82044e8e5906e54680127ff92" + // binding nonce [0]
-		"0000000000000002" + // signer [1] index
-		"04f28773c2d975288bc7d1d205c3748651b075fbc6610e58cddeeddf8f19405aa80ab0902e8d880a89758212eb65cdaf473a1a06da521fa91f29b5cb52db03ed81" + // hiding nonce [1]
-		"049e2158f0d7c0d5f26c3791efefa79597654e7a2b2464f52b1ee6c1347769ef570712fcdd1b9053f09003a3481fa7762e9ffd7c8ef35a38509e2fbf2629008373" + // binding nonce [1]
-		"0000000000000003" + // signer [2] index
-		"04499fdf9e895e719cfd64e67f07d38e3226aa7b63678949e6e49b241a60e823e4cac2f6c4b54e855190f044e4a7b3d464464279c27a3f95bcc65f40d403a13f5b" + // hiding nonce [2]
-		"0422213b78f3dcfbdfeb76cc1731c1ba318b2b0c32f081e206f50618fa7eaf5aa3dd81b694ec3a60bad2a203d8eedc863fe476add5cf7391740d86e5c8718a3051" // binding nonce [2]
-
-	var commitments []*NonceCommitment
-	for i, c := range hidingNonceCommitments {
-		hnx, _ := new(big.Int).SetString(c[0], 16)
-		hny, _ := new(big.Int).SetString(c[1], 16)
-
-		bnx, _ := new(big.Int).SetString(bindingNonceCommitments[i][0], 16)
-		bny, _ := new(big.Int).SetString(bindingNonceCommitments[i][1], 16)
-
-		commitments = append(commitments, &NonceCommitment{
-			signerIndex:            uint64(i + 1),
-			hidingNonceCommitment:  &Point{hnx, hny},
-			bindingNonceCommitment: &Point{bnx, bny},
-		})
-	}
-
-	signer := createSigners(t)[0]
-	encoded := signer.encodeGroupCommitment(commitments)
-
-	testutils.AssertStringsEqual(
-		t,
-		"encoded data",
-		expectedEncoded,
-		hex.EncodeToString(encoded),
-	)
-}
-
-func TestDeriveInterpolatingValue(t *testing.T) {
-	var tests = map[string]struct {
-		xi       uint64
-		L        []uint64
-		expected string
-	}{
-		// Lagrange coefficient l_0 is:
-		//
-		//       (x-4)(x-5)
-		// l_0 = ----------
-		//       (1-4)(1-5)
-		//
-		// Since x is always 0 for this function, l_0 = 20/12 (mod Q).
-		//
-		// Then we calculate ((12^-1 mod Q) * 20) mod Q
-		// where Q is the order of secp256k1.
-		//
-		"xi = 1, L = {1, 4, 5}": {
-			xi:       1,
-			L:        []uint64{1, 4, 5},
-			expected: "38597363079105398474523661669562635950945854759691634794201721047172720498114",
-		},
-		// Lagrange coefficient l_1 is:
-		//
-		//       (x-1)(x-5)
-		// l_1 = ----------
-		//       (4-1)(4-5)
-		//
-		// Since x is always 0 for this function, l_0 = 5/-3 (mod Q).
-		// Given the negative denominator and mod Q, the number will be
-		// l_0 = 5/(Q-3).
-		//
-		// Then we calculate (((Q-3)^-1 mod Q) * 5) mod Q
-		// where Q is the order of secp256k1.
-		//
-		"xi = 4, L = {1, 4, 5}": {
-			xi:       4,
-			L:        []uint64{1, 4, 5},
-			expected: "77194726158210796949047323339125271901891709519383269588403442094345440996223",
-		},
-		// Lagrange coefficient l_2 is:
-		//
-		//       (x-1)(x-4)
-		// l_1 = ----------
-		//       (5-1)(5-4)
-		//
-		// Since x is always 0 for this function, l_0 = 4/4 (mod Q).
-		//
-		// Then we calculate ((1^-1 mod Q) * 1) mod Q
-		// where Q is the order of secp256k1.
-		//
-		"xi = 5, L = {1, 4, 5}": {
-			xi:       5,
-			L:        []uint64{1, 4, 5},
-			expected: "1",
-		},
-	}
-
-	signer := createSigners(t)[0]
-	for testName, test := range tests {
-		t.Run(testName, func(t *testing.T) {
-			result := signer.deriveInterpolatingValue(test.xi, test.L)
-			testutils.AssertStringsEqual(
-				t,
-				"interpolating value",
-				test.expected,
-				result.Text(10),
-			)
 		})
 	}
 }


### PR DESCRIPTION
~~Depends on #8~~

The PR implements the `Aggregate` function as specified in  [FROST], section 5.3. Signature Share Aggregation, based on @eth-r's prototype.

Moreover, it proposes a new structure of sharing functionality between the Coordinator and Signers. The base logic is placed in the `Participant` structure that is embedded by `Coordinator` and `Signer`. This allows us not to repeat the logic while keeping the flexibility of having a separate `Coordinator`. The `Coordinator` could be just another goroutine on a machine running one of the `Signers` but also a completely separate instance, depending on a use case. 