### PR TITLE
Follow-up: Increase the number of attempts for the FROST roundtrip test

### DIFF
--- a/frost/frost_test.go
+++ b/frost/frost_test.go
@@ -33,7 +33,7 @@ func TestFrostRoundtrip(t *testing.T) {
 			publicKey := signers[0].publicKey
 
 			isSignatureValid := false
-			maxAttempts := 5
+			maxAttempts := 20
 
 			// From [BIP-340]:
 			// Let k' = int(rand) mod n[13].
@@ -64,7 +64,8 @@ func TestFrostRoundtrip(t *testing.T) {
 				)
 				if err != nil {
 					fmt.Printf(
-						"signature verification error on attempt [%v]: [%v]\n",
+						"[%v] signature verification error on attempt [%v]: [%v]\n",
+						testName,
 						i,
 						err,
 					)


### PR DESCRIPTION
With maxAttempts = 5 we have around a 3% chance that this test will not pass due to bad luck. With maxAttempts = 20 we have 0.0001% chance of not passing.

Also, added a context to error messages printed to better distinguish test cases.

It is a follow-up for #11.