### PR TITLE
Validate the number of commitments and signature shares

### DIFF
--- a/frost/coordinator.go
+++ b/frost/coordinator.go
@@ -2,24 +2,28 @@ package frost
 
 import (
 	"errors"
+	"fmt"
 	"math/big"
 )
 
 // Coordinator represents a coordinator of the [FROST] signing protocol.
 type Coordinator struct {
 	Participant
+	threshold int
 }
 
 // NewCoordinator creates a new [FROST] Coordinator instance.
 func NewCoordinator(
 	ciphersuite Ciphersuite,
 	publicKey *Point,
+	threshold int,
 ) *Coordinator {
 	return &Coordinator{
 		Participant: Participant{
 			ciphersuite: ciphersuite,
 			publicKey:   publicKey,
 		},
+		threshold: threshold,
 	}
 }
 
@@ -64,7 +68,22 @@ func (c *Coordinator) Aggregate(
 	//    - (R, z), a Schnorr signature consisting of an Element R and
 	//      Scalar z.
 
-	// TODO: validate the number of signature shares
+	if len(signatureShares) < c.threshold {
+		return nil, fmt.Errorf(
+			"not enough shares; has [%d] for threshold [%d]",
+			len(signatureShares),
+			c.threshold,
+		)
+	}
+
+	if len(commitments) != len(signatureShares) {
+		return nil, fmt.Errorf(
+			"the number of commitments and signature shares do not match; "+
+				"has [%d] commitments and [%d] signature shares",
+			len(commitments),
+			len(signatureShares),
+		)
+	}
 
 	validationErrors, _ := c.validateGroupCommitmentsBase(commitments)
 	if len(validationErrors) != 0 {

--- a/frost/coordinator.go
+++ b/frost/coordinator.go
@@ -10,6 +10,7 @@ import (
 type Coordinator struct {
 	Participant
 	threshold int
+	groupSize int
 }
 
 // NewCoordinator creates a new [FROST] Coordinator instance.
@@ -17,6 +18,7 @@ func NewCoordinator(
 	ciphersuite Ciphersuite,
 	publicKey *Point,
 	threshold int,
+	groupSize int,
 ) *Coordinator {
 	return &Coordinator{
 		Participant: Participant{
@@ -24,6 +26,7 @@ func NewCoordinator(
 			publicKey:   publicKey,
 		},
 		threshold: threshold,
+		groupSize: groupSize,
 	}
 }
 
@@ -68,11 +71,21 @@ func (c *Coordinator) Aggregate(
 	//    - (R, z), a Schnorr signature consisting of an Element R and
 	//      Scalar z.
 
+	// MIN_PARTICIPANTS <= NUM_PARTICIPANTS
 	if len(signatureShares) < c.threshold {
 		return nil, fmt.Errorf(
 			"not enough shares; has [%d] for threshold [%d]",
 			len(signatureShares),
 			c.threshold,
+		)
+	}
+
+	// NUM_PARTICIPANTS <= MAX_PARTICIPANTS
+	if len(signatureShares) > c.groupSize {
+		return nil, fmt.Errorf(
+			"too many shares; has [%d] for group size [%d]",
+			len(signatureShares),
+			c.groupSize,
 		)
 	}
 

--- a/frost/coordinator_test.go
+++ b/frost/coordinator_test.go
@@ -1,0 +1,59 @@
+package frost
+
+import (
+	"testing"
+
+	"threshold.network/roast/internal/testutils"
+)
+
+// This test covers failure paths in the Aggregate function. The happy path is
+// covered as a part of the roundtrip test in frost_test.go.
+func TestAggregate_Failures(t *testing.T) {
+	message := []byte("For even the very wise cannot see all ends")
+
+	signers := createSigners(t)
+	publicKey := signers[0].publicKey
+
+	nonces, commitments := executeRound1(t, signers)
+	signatureShares := executeRound2(t, signers, message, nonces, commitments)
+
+	coordinator := NewCoordinator(ciphersuite, publicKey, threshold)
+
+	tests := map[string]struct {
+		numberOfCommitments     int
+		numberOfSignatureShares int
+		expectedErr             string
+	}{
+		"number of commitments and signature shares do not match": {
+			numberOfCommitments:     groupSize,
+			numberOfSignatureShares: groupSize - 1,
+			expectedErr:             "the number of commitments and signature shares do not match; has [100] commitments and [99] signature shares",
+		},
+		"number of commitments and signature shares below threshold": {
+			numberOfCommitments:     threshold - 1,
+			numberOfSignatureShares: threshold - 1,
+			expectedErr:             "not enough shares; has [50] for threshold [51]",
+		},
+	}
+
+	for testName, test := range tests {
+		t.Run(testName, func(t *testing.T) {
+			signature, err := coordinator.Aggregate(
+				message,
+				commitments[:test.numberOfCommitments],
+				signatureShares[:test.numberOfSignatureShares],
+			)
+
+			testutils.AssertStringsEqual(
+				t,
+				"aggregate signature share error message",
+				test.expectedErr,
+				err.Error(),
+			)
+
+			if signature != nil {
+				t.Error("expected nil signature")
+			}
+		})
+	}
+}

--- a/frost/frost_test.go
+++ b/frost/frost_test.go
@@ -51,7 +51,7 @@ func TestFrostRoundtrip(t *testing.T) {
 				nonces, commitments := executeRound1(t, signers)
 				signatureShares := executeRound2(t, signers, message, nonces, commitments)
 
-				coordinator := NewCoordinator(ciphersuite, publicKey, threshold)
+				coordinator := NewCoordinator(ciphersuite, publicKey, threshold, groupSize)
 				signature, err := coordinator.Aggregate(message, commitments, signatureShares)
 				if err != nil {
 					t.Fatal(err)

--- a/frost/frost_test.go
+++ b/frost/frost_test.go
@@ -51,7 +51,7 @@ func TestFrostRoundtrip(t *testing.T) {
 				nonces, commitments := executeRound1(t, signers)
 				signatureShares := executeRound2(t, signers, message, nonces, commitments)
 
-				coordinator := NewCoordinator(ciphersuite, publicKey)
+				coordinator := NewCoordinator(ciphersuite, publicKey, threshold)
 				signature, err := coordinator.Aggregate(message, commitments, signatureShares)
 				if err != nil {
 					t.Fatal(err)


### PR DESCRIPTION
The number of signature shares should at least be equal to the group threshold when aggregating them. We now validate their number to produce a clear error message as soon as possible. Also, the number of commitments and signature shares should be the same so that the produced signature is valid.